### PR TITLE
Syntax and Typing for External Allocations

### DIFF
--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -249,7 +249,7 @@ let iter_on_occurrences
       | Texp_probe_is_enabled _ | Texp_exclave _
       (* CR-someday let_mutable: maybe iterate on mutvar? *)
       | Texp_mutvar _ | Texp_setmutvar _
-      | Texp_open _ | Texp_src_pos | Texp_overwrite _ | Texp_hole _ -> ());
+      | Texp_open _ | Texp_src_pos | Texp_overwrite _ | Texp_hole _ | Texp_alloc _ -> ());
       default_iterator.expr sub e);
 
   (* Remark: some types get iterated over twice due to how constraints are

--- a/jane/doc/extensions/_05-modes/intro.md
+++ b/jane/doc/extensions/_05-modes/intro.md
@@ -69,6 +69,7 @@ programs.
 * [Modes for moving between threads (portability and
   contention)](#portability-contention)
 * [Modes for aliasing (uniqueness and linearity)](#uniqueness-linearity)
+* [Modes for garbage collection] (#externality)
 
 # Modes for scope {#locality}
 
@@ -277,3 +278,44 @@ while observing closures capture all values at visibility *read*.
 Statefulness is irrelevant for types that do not contain functions, and values of such
 types *mode cross* on the statefulness axis; they may be used as stateless
 even when they are stateful.
+
+
+# Modes for garbage collection {#externality}
+
+## Future modes: Externality
+
+|--------------|
+| **internal** |
+| `|`          |
+| external64   |
+| `|`          |
+| external_    |
+{: .table}
+
+Externality is a future axis which records whether a value may safely be ignored
+by the GC.  This may be because they are OCaml "immediates" (values represented
+by a tagged integer), because they are unboxed types like `float#` or `int32#`,
+or because they are allocated elsewhere.
+
+The compiler uses the externality axis for certain runtime optimizations. In
+particular, updating a mutable reference to a value that is `external_` can skip
+the write barrier (i.e., it does not need a call to `caml_modify`).
+
+The axis has three possible values, with `external_ < external64 < internal`.
+* `external_` means that the value may be safely ignored by the
+  GC. Examples of external values include values of type `int` , values of unboxed
+  types like `float#`, or other values represented by a tagged integer like `None`
+  or `[]`.
+* `external64` means the value can be safely ignored by the GC
+  _on 64-bit systems_. The only 32-bit target currently supported by the OxCaml
+  compiler is bytecode. Note that, although JavaScript and WASM are 32-bit
+  platforms and the compiler goes through bytecode to reach them, they still
+  count as 64-bit systems for the purpose of this axis because of their unique
+  data models.
+* `internal` means values of the type may need to be scanned. This includes all
+  standard OCaml values that are represented by heap-allocated blocks and are
+  managed by the OCaml GC (like lists and records).
+
+Like locality, externality is irrelevant for types like `int` or `char` that
+*never* cause allocations on the OCaml heap, and so these types mode-cross on
+the externality axis.

--- a/jane/doc/extensions/_05-modes/syntax.md
+++ b/jane/doc/extensions/_05-modes/syntax.md
@@ -10,7 +10,7 @@ A mode expression is a space-delimited list of modes.
 
 ```
 mode ::= locality | uniqueness | linearity | portability | contention
-       | yield | statefulness | visibility
+       | yield | statefulness | visibility | externality
 
 (* these are the modal axes: *)
 locality ::= `global` | `local`
@@ -21,6 +21,7 @@ contention ::= `uncontended` | `shared` | `contended`
 yield ::= `unyielding` | `yielding`
 statefulness ::= `stateless` | `observing` | `stateful`
 visibility ::= `read_write` | `read` | `immutable`
+externality ::= `external_` | `external64` | `internal`
 
 modes ::= mode
       |  mode modes
@@ -164,7 +165,7 @@ Modalities are used to describe the relationship between a container and an
 element in that container; for example, if you have a record field `x` with
 a `portable` modality, then `r.x` is `portable` even if `r` is `nonportable`.
 We say that the `portable` modality applied to the `nonportable` record mode
-produces the `portable` mode of the field. 
+produces the `portable` mode of the field.
 
 Modalities work differently on future axes vs. past axes. On a future axis, the
 modality imposes an upper bound on the mode (thus always lowering that
@@ -180,7 +181,7 @@ as the mode of the record.) For future axes, this would be the top mode; for
 past axes, this would be the bottom mode. These are the identity modalities:
 
 ```ocaml
-local unique once nonportable uncontended unyielding stateless immutable
+local unique once nonportable uncontended unyielding stateless immutable internal
 ```
 
 Note that a legacy mode might or might not be the same as the identity modality.

--- a/jane/doc/extensions/_06-kinds/intro.md
+++ b/jane/doc/extensions/_06-kinds/intro.md
@@ -69,10 +69,10 @@ the bounds:
 
 ```
 value mod global contended portable aliased many unyielding immutable stateless
-          non_float external_
+          external_ non_float
 ```
 
-This kind indicates that `int` mode crosses on all eight of our modal axes. In
+This kind indicates that `int` mode crosses on all nine of our modal axes. In
 addition, `int`s are not `float`s and they do not need to be garbage-collected
 (they are `external_` to the garbage collector).
 

--- a/jane/doc/extensions/_06-kinds/non-modal.md
+++ b/jane/doc/extensions/_06-kinds/non-modal.md
@@ -6,32 +6,7 @@ title: Non-modal bounds
 
 # Non-modal bounds
 
-## Externality
-
-The externality axis records whether all a type's values may safely be ignored
-by the GC.  This may be because they are OCaml "immediates" (values represented
-by a tagged integer), because they are unboxed types like `float#` or `int32#`,
-or because they are allocated elsewhere.
-
-The axis has three possible values, with `external_ < external64 < internal`.
-* `external_` means that all values of the type are safely ignored by the
-  GC.
-* `external64` means that all values of the type are safely ignored by the GC
-  _on 64-bit systems_. The only 32-bit target currently supported by the OxCaml
-  compiler is bytecode. Note that, although JavaScript and WASM are 32-bit
-  platforms and the compiler goes through bytecode to reach them, they still
-  count as 64-bit systems for the purpose of this axis because of their unique
-  data models.
-* `internal` means values of the type may need to be scanned.
-
-The compiler uses the externality axis for certain runtime optimizations. In
-particular, updating a mutable reference to a type that is `external_` can skip
-the write barrier (i.e., it does not need a call to `caml_modify`).
-
-In the future, we plan to make externality a mode, rather than just a property
-of types.
-
-## Nullability
+# Nullability
 
 The nullability axis records whether `NULL` (the machine word 0) is a possible
 value of a type, and is used to support the non-allocating option `'a or_null`

--- a/jane/doc/extensions/_06-kinds/syntax.md
+++ b/jane/doc/extensions/_06-kinds/syntax.md
@@ -10,7 +10,6 @@ title: Syntax
 [manual]: https://ocaml.org/manual/language.html
 [unboxed types]: ../../unboxed-types/intro
 [nullability]: ../non-modal#nullability
-[externality]: ../non-modal#externality
 
 This page describes user-facing concerns about kind annotations. You may
 want to read an [overview][] of the kind system first.
@@ -98,7 +97,7 @@ We thus give the non-primitive `value` the shorter name.
 
 Beyond just kind abbreviations, we also have one bounds abbreviation:
 `everything`. `everything` describes a maximal amount of crossing on
-*deep* axes: modal axes and externality. The `nullability` and `separability` bounds, due to
+modal axes. The `nullability` and `separability` bounds, due to
 their shallowness, are considered separately.
 
 The abbreviations defined in the language are as follows:
@@ -108,7 +107,7 @@ The abbreviations defined in the language are as follows:
 
     Values whose types have kinds that include `mod everything` do not...
 
-    * ... allocate memory: this allows them to mode-cross to `global` and be
+    * ... allocate memory: this allows them to mode-cross to `global` and
       `external_`.
     * ... contain functions: this allows them to mode-cross to `many portable
       unyielding stateless` (all of which only affect functions).
@@ -163,9 +162,8 @@ The abbreviations defined in the language are as follows:
 
     `external64` describes exactly this scenario: on a 64-bit machine, values
     of this type are never pointers to allocations managed by the OCaml garbage
-    collector. This means that mutations of values of this type do not require a
-    call to `caml_modify` (on 64-bit machines). See also the documentation on
-    [externality][].
+    collector. See also the documentation on
+    [externality](../_05-modes/intro.md#future-modes-externality).
 
 * `immutable_data =
      value mod many contended portable unyielding immutable stateless non_float`

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1281,6 +1281,11 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       Location.todo_overwrite_not_implemented ~kind:"Translcore" e.exp_loc
   | Texp_hole _ ->
       Location.todo_overwrite_not_implemented ~kind:"Translcore" e.exp_loc
+  (* CR jcutler: Currently, [malloc_] has no semantic meaning. We simply just
+     translate it to a regular heap allocation. This will obviously need to be
+     changed when we actually want malloc_ to malloc.
+   *)
+  | Texp_alloc (e,_) -> transl_exp ~scopes sort e
 
 and pure_module m =
   match m.mod_desc with

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -252,6 +252,7 @@ module Exp = struct
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pexp_extension a)
   let unreachable ?loc ?attrs () = mk ?loc ?attrs Pexp_unreachable
   let stack ?loc ?attrs e = mk ?loc ?attrs (Pexp_stack e)
+  let malloc ?loc ?attrs e = mk ?loc ?attrs (Pexp_malloc e)
   let comprehension ?loc ?attrs e = mk ?loc ?attrs (Pexp_comprehension e)
   let overwrite ?loc ?attrs a b = mk ?loc ?attrs (Pexp_overwrite (a, b))
   let hole ?loc ?attrs () = mk ?loc ?attrs Pexp_hole

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -214,6 +214,7 @@ module Exp:
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> expression
     val unreachable: ?loc:loc -> ?attrs:attrs -> unit -> expression
     val stack : ?loc:loc -> ?attrs:attrs -> expression -> expression
+    val malloc : ?loc:loc -> ?attrs:attrs -> expression -> expression
     val comprehension :
       ?loc:loc -> ?attrs:attrs -> comprehension_expression -> expression
     val overwrite : ?loc:loc -> ?attrs:attrs -> expression -> expression -> expression

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -539,6 +539,7 @@ module E = struct
     | Pexp_extension x -> sub.extension sub x
     | Pexp_unreachable -> ()
     | Pexp_stack e -> sub.expr sub e
+    | Pexp_malloc e -> sub.expr sub e
     | Pexp_comprehension e -> iter_comp_exp sub e
     | Pexp_overwrite (e1, e2) -> sub.expr sub e1; sub.expr sub e2
     | Pexp_hole -> ()

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -615,6 +615,7 @@ module E = struct
     | Pexp_extension x -> extension ~loc ~attrs (sub.extension sub x)
     | Pexp_unreachable -> unreachable ~loc ~attrs ()
     | Pexp_stack e -> stack ~loc ~attrs (sub.expr sub e)
+    | Pexp_malloc e -> malloc ~loc ~attrs (sub.expr sub e)
     | Pexp_comprehension c -> comprehension ~loc ~attrs (map_cexp sub c)
     | Pexp_overwrite (e1, e2) -> overwrite ~loc ~attrs (sub.expr sub e1) (sub.expr sub e2)
     | Pexp_hole -> hole ~loc ~attrs ()

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -317,6 +317,7 @@ let rec add_expr bv exp =
       end
   | Pexp_extension e -> handle_extension e
   | Pexp_stack e -> add_expr bv e
+  | Pexp_malloc e -> add_expr bv e
   | Pexp_overwrite (e1, e2) -> add_expr bv e1; add_expr bv e2
   | Pexp_hole -> ()
   | Pexp_unreachable -> ()

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -86,6 +86,7 @@ let keyword_table =
     "rec", REC;
     "sig", SIG;
     "stack_", STACK;
+    "malloc_", MALLOC;
     "struct", STRUCT;
     "then", THEN;
     "to", TO;

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1090,6 +1090,7 @@ let maybe_pmod_constraint mode expr =
 %token <string> HASHOP        "##" (* just an example *)
 %token SIG                    "sig"
 %token STACK                  "stack_"
+%token MALLOC                 "malloc_"
 %token STAR                   "*"
 %token <string * Location.t * string option>
        STRING                 "\"hello\"" (* just an example *)
@@ -2911,6 +2912,7 @@ fun_expr:
   | simple_expr nonempty_llist(labeled_simple_expr)
       { mkexp ~loc:$sloc (Pexp_apply($1, $2)) }
   | stack(simple_expr) %prec below_HASH { $1 }
+  | malloc(simple_expr) %prec below_HASH { $1 }
   | labeled_tuple %prec below_COMMA
       { mkexp ~loc:$sloc (Pexp_tuple $1) }
   | maybe_stack (
@@ -4594,6 +4596,9 @@ optional_atat_modalities_expr:
 %inline maybe_stack(expr):
   | expr { $1 }
   | stack(expr) { $1 }
+
+%inline malloc(expr):
+  | MALLOC expr { mkexp ~loc:$sloc (Pexp_malloc $2) }
 
 %inline param_type:
   | mktyp(

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -515,6 +515,7 @@ and expression_desc =
   | Pexp_extension of extension  (** [[%id]] *)
   | Pexp_unreachable  (** [.] *)
   | Pexp_stack of expression (** stack_ exp *)
+  | Pexp_malloc of expression (** malloc_ exp *)
   | Pexp_comprehension of comprehension_expression
     (** [[? BODY ...CLAUSES... ?]], where:
           - [?] is either [""] (list), [:] (immutable array), or [|] (array).

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -451,6 +451,9 @@ and expression i ppf x =
   | Pexp_stack e ->
       line i ppf "Pexp_stack\n";
       expression i ppf e
+  | Pexp_malloc e ->
+      line i ppf "Pexp_malloc\n";
+      expression i ppf e
   | Pexp_comprehension c ->
       line i ppf "Pexp_comprehension\n";
       comprehension_expression i ppf c

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -475,6 +475,9 @@ and expression i ppf x =
   | Pexp_stack e ->
       line i ppf "Pexp_stack\n";
       expression i ppf e
+  | Pexp_malloc e ->
+      line i ppf "Pexp_malloc\n";
+      expression i ppf e
   | Pexp_comprehension c ->
       line i ppf "Pexp_comprehension\n";
       comprehension_expression i ppf c

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -89,13 +89,13 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def_rec>
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
-          value_mode global,many,portable,unyielding,stateful;imply(unique,uncontended,read_write)(modevar#3[aliased,contended,immutable .. unique,uncontended,read_write])
+          value_mode global,many,portable,unyielding,stateful,internal;imply(unique,uncontended,read_write)(modevar#3[aliased,contended,immutable .. unique,uncontended,read_write])
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
-          alloc_mode global,many,portable,unyielding,stateful;id(modevar#9[aliased,contended,immutable .. unique,uncontended,read_write])
+          alloc_mode global,many,portable,unyielding,stateful,internal;id(modevar#9[aliased,contended,immutable .. unique,uncontended,read_write])
           []
           Tfunction_cases (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
-          alloc_mode global,many,nonportable,unyielding,stateful;aliased,uncontended,read_write
+          alloc_mode global,many,nonportable,unyielding,stateful,internal;aliased,uncontended,read_write
           value
             [
               <case>
@@ -110,7 +110,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
               <case>
                 pattern (test_locations.ml[19,572+4]..test_locations.ml[19,572+5])
                   Tpat_var "n"
-                  value_mode global,many,portable,unyielding,stateless;unique,uncontended,read_write
+                  value_mode global,many,portable,unyielding,stateless,external_;unique,uncontended,read_write
                 expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+34])
                   Texp_apply
                   apply_mode Tail

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -1,78 +1,78 @@
 [
-  structure_item
+  structure_item 
     Pstr_value Rec
     [
       <def>
-        pattern
-          Ppat_var "fib"
-        expression
+        pattern 
+          Ppat_var "fib" 
+        expression 
           Pexp_function
           []
           None
-          Pfunction_cases
+          Pfunction_cases 
             [
               <case>
-                pattern
+                pattern 
                   Ppat_or
-                  pattern
+                  pattern 
                     Ppat_constant PConst_int (0,None)
-                  pattern
+                  pattern 
                     Ppat_constant PConst_int (1,None)
-                expression
+                expression 
                   Pexp_constant PConst_int (1,None)
               <case>
-                pattern
-                  Ppat_var "n"
-                expression
+                pattern 
+                  Ppat_var "n" 
+                expression 
                   Pexp_apply
-                  expression
-                    Pexp_ident "+"
+                  expression 
+                    Pexp_ident "+" 
                   [
                     <arg>
                     Nolabel
-                      expression
+                      expression 
                         Pexp_apply
-                        expression
-                          Pexp_ident "fib"
+                        expression 
+                          Pexp_ident "fib" 
                         [
                           <arg>
                           Nolabel
-                            expression
+                            expression 
                               Pexp_apply
-                              expression
-                                Pexp_ident "-"
+                              expression 
+                                Pexp_ident "-" 
                               [
                                 <arg>
                                 Nolabel
-                                  expression
-                                    Pexp_ident "n"
+                                  expression 
+                                    Pexp_ident "n" 
                                 <arg>
                                 Nolabel
-                                  expression
+                                  expression 
                                     Pexp_constant PConst_int (1,None)
                               ]
                         ]
                     <arg>
                     Nolabel
-                      expression
+                      expression 
                         Pexp_apply
-                        expression
-                          Pexp_ident "fib"
+                        expression 
+                          Pexp_ident "fib" 
                         [
                           <arg>
                           Nolabel
-                            expression
+                            expression 
                               Pexp_apply
-                              expression
-                                Pexp_ident "-"
+                              expression 
+                                Pexp_ident "-" 
                               [
                                 <arg>
                                 Nolabel
-                                  expression
-                                    Pexp_ident "n"
+                                  expression 
+                                    Pexp_ident "n" 
                                 <arg>
                                 Nolabel
-                                  expression
+                                  expression 
                                     Pexp_constant PConst_int (2,None)
                               ]
                         ]
@@ -83,94 +83,94 @@
 
 let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
 [
-  structure_item
+  structure_item 
     Tstr_value Rec
     [
       <def_rec>
-        pattern
+        pattern 
           Tpat_var "fib"
           value_mode global,many,portable,unyielding,stateful,internal;imply(unique,uncontended,read_write)(modevar#3[aliased,contended,immutable .. unique,uncontended,read_write])
-        expression
+        expression 
           Texp_function
           alloc_mode global,many,portable,unyielding,stateful,internal;id(modevar#9[aliased,contended,immutable .. unique,uncontended,read_write])
           []
-          Tfunction_cases
+          Tfunction_cases 
           alloc_mode global,many,nonportable,unyielding,stateful,internal;aliased,uncontended,read_write
           value
             [
               <case>
-                pattern
+                pattern 
                   Tpat_or
-                  pattern
+                  pattern 
                     Tpat_constant Const_int 0
-                  pattern
+                  pattern 
                     Tpat_constant Const_int 1
-                expression
+                expression 
                   Texp_constant Const_int 1
               <case>
-                pattern
+                pattern 
                   Tpat_var "n"
                   value_mode global,many,portable,unyielding,stateless,external_;unique,uncontended,read_write
-                expression
+                expression 
                   Texp_apply
                   apply_mode Tail
                   locality_mode global
-                  expression
+                  expression 
                     Texp_ident "Stdlib!.+"
                   [
                     <arg>
                       Nolabel
-                      expression
+                      expression 
                         Texp_apply
                         apply_mode Default
                         locality_mode global
-                        expression
+                        expression 
                           Texp_ident "fib"
                         [
                           <arg>
                             Nolabel
-                            expression
+                            expression 
                               Texp_apply
                               apply_mode Default
                               locality_mode global
-                              expression
+                              expression 
                                 Texp_ident "Stdlib!.-"
                               [
                                 <arg>
                                   Nolabel
-                                  expression
+                                  expression 
                                     Texp_ident "n"
                                 <arg>
                                   Nolabel
-                                  expression
+                                  expression 
                                     Texp_constant Const_int 1
                               ]
                         ]
                     <arg>
                       Nolabel
-                      expression
+                      expression 
                         Texp_apply
                         apply_mode Default
                         locality_mode global
-                        expression
+                        expression 
                           Texp_ident "fib"
                         [
                           <arg>
                             Nolabel
-                            expression
+                            expression 
                               Texp_apply
                               apply_mode Default
                               locality_mode global
-                              expression
+                              expression 
                                 Texp_ident "Stdlib!.-"
                               [
                                 <arg>
                                   Nolabel
-                                  expression
+                                  expression 
                                     Texp_ident "n"
                                 <arg>
                                   Nolabel
-                                  expression
+                                  expression 
                                     Texp_constant Const_int 2
                               ]
                         ]

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -89,13 +89,13 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def_rec>
         pattern 
           Tpat_var "fib"
-          value_mode global,many,portable,unyielding,stateful;imply(unique,uncontended,read_write)(modevar#3[aliased,contended,immutable .. unique,uncontended,read_write])
+          value_mode global,many,portable,unyielding,stateful,internal;imply(unique,uncontended,read_write)(modevar#3[aliased,contended,immutable .. unique,uncontended,read_write])
         expression 
           Texp_function
-          alloc_mode global,many,portable,unyielding,stateful;id(modevar#9[aliased,contended,immutable .. unique,uncontended,read_write])
+          alloc_mode global,many,portable,unyielding,stateful,internal;id(modevar#9[aliased,contended,immutable .. unique,uncontended,read_write])
           []
           Tfunction_cases 
-          alloc_mode global,many,nonportable,unyielding,stateful;aliased,uncontended,read_write
+          alloc_mode global,many,nonportable,unyielding,stateful,internal;aliased,uncontended,read_write
           value
             [
               <case>
@@ -110,7 +110,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
               <case>
                 pattern 
                   Tpat_var "n"
-                  value_mode global,many,portable,unyielding,stateless;unique,uncontended,read_write
+                  value_mode global,many,portable,unyielding,stateless,external_;unique,uncontended,read_write
                 expression 
                   Texp_apply
                   apply_mode Tail

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -1,78 +1,78 @@
 [
-  structure_item 
+  structure_item
     Pstr_value Rec
     [
       <def>
-        pattern 
-          Ppat_var "fib" 
-        expression 
+        pattern
+          Ppat_var "fib"
+        expression
           Pexp_function
           []
           None
-          Pfunction_cases 
+          Pfunction_cases
             [
               <case>
-                pattern 
+                pattern
                   Ppat_or
-                  pattern 
+                  pattern
                     Ppat_constant PConst_int (0,None)
-                  pattern 
+                  pattern
                     Ppat_constant PConst_int (1,None)
-                expression 
+                expression
                   Pexp_constant PConst_int (1,None)
               <case>
-                pattern 
-                  Ppat_var "n" 
-                expression 
+                pattern
+                  Ppat_var "n"
+                expression
                   Pexp_apply
-                  expression 
-                    Pexp_ident "+" 
+                  expression
+                    Pexp_ident "+"
                   [
                     <arg>
                     Nolabel
-                      expression 
+                      expression
                         Pexp_apply
-                        expression 
-                          Pexp_ident "fib" 
+                        expression
+                          Pexp_ident "fib"
                         [
                           <arg>
                           Nolabel
-                            expression 
+                            expression
                               Pexp_apply
-                              expression 
-                                Pexp_ident "-" 
+                              expression
+                                Pexp_ident "-"
                               [
                                 <arg>
                                 Nolabel
-                                  expression 
-                                    Pexp_ident "n" 
+                                  expression
+                                    Pexp_ident "n"
                                 <arg>
                                 Nolabel
-                                  expression 
+                                  expression
                                     Pexp_constant PConst_int (1,None)
                               ]
                         ]
                     <arg>
                     Nolabel
-                      expression 
+                      expression
                         Pexp_apply
-                        expression 
-                          Pexp_ident "fib" 
+                        expression
+                          Pexp_ident "fib"
                         [
                           <arg>
                           Nolabel
-                            expression 
+                            expression
                               Pexp_apply
-                              expression 
-                                Pexp_ident "-" 
+                              expression
+                                Pexp_ident "-"
                               [
                                 <arg>
                                 Nolabel
-                                  expression 
-                                    Pexp_ident "n" 
+                                  expression
+                                    Pexp_ident "n"
                                 <arg>
                                 Nolabel
-                                  expression 
+                                  expression
                                     Pexp_constant PConst_int (2,None)
                               ]
                         ]
@@ -83,94 +83,107 @@
 
 let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
 [
-  structure_item 
+  structure_item
     Tstr_value Rec
     [
       <def_rec>
-        pattern 
+        pattern
           Tpat_var "fib"
+<<<<<<< HEAD
           value_mode global,many,portable,unyielding,stateful,internal;imply(unique,uncontended,read_write)(modevar#3[aliased,contended,immutable .. unique,uncontended,read_write])
         expression 
           Texp_function
           alloc_mode global,many,portable,unyielding,stateful,internal;id(modevar#9[aliased,contended,immutable .. unique,uncontended,read_write])
           []
           Tfunction_cases 
+=======
+          value_mode global,many,portable,unyielding,stateful,internal;imply(unique,uncontended,read_write)(modevar#1[aliased,contended,immutable .. unique,uncontended,read_write])
+        expression
+          Texp_function
+          alloc_mode global,many,portable,unyielding,stateful,internal;id(modevar#7[aliased,contended,immutable .. unique,uncontended,read_write])
+          []
+          Tfunction_cases
+>>>>>>> 6206867253 (add externality modal axis)
           alloc_mode global,many,nonportable,unyielding,stateful,internal;aliased,uncontended,read_write
           value
             [
               <case>
-                pattern 
+                pattern
                   Tpat_or
-                  pattern 
+                  pattern
                     Tpat_constant Const_int 0
-                  pattern 
+                  pattern
                     Tpat_constant Const_int 1
-                expression 
+                expression
                   Texp_constant Const_int 1
               <case>
-                pattern 
+                pattern
                   Tpat_var "n"
                   value_mode global,many,portable,unyielding,stateless,external_;unique,uncontended,read_write
+<<<<<<< HEAD
                 expression 
+=======
+                expression
+>>>>>>> 6206867253 (add externality modal axis)
                   Texp_apply
                   apply_mode Tail
                   locality_mode global
-                  expression 
+                  expression
                     Texp_ident "Stdlib!.+"
                   [
                     <arg>
                       Nolabel
-                      expression 
+                      expression
                         Texp_apply
                         apply_mode Default
                         locality_mode global
-                        expression 
+                        expression
                           Texp_ident "fib"
                         [
                           <arg>
                             Nolabel
-                            expression 
+                            expression
                               Texp_apply
                               apply_mode Default
                               locality_mode global
-                              expression 
+                              expression
                                 Texp_ident "Stdlib!.-"
                               [
                                 <arg>
                                   Nolabel
-                                  expression 
+                                  expression
                                     Texp_ident "n"
                                 <arg>
                                   Nolabel
-                                  expression 
+                                  expression
                                     Texp_constant Const_int 1
                               ]
                         ]
                     <arg>
                       Nolabel
-                      expression 
+                      expression
                         Texp_apply
                         apply_mode Default
                         locality_mode global
-                        expression 
+                        expression
                           Texp_ident "fib"
                         [
                           <arg>
                             Nolabel
-                            expression 
+                            expression
                               Texp_apply
                               apply_mode Default
                               locality_mode global
-                              expression 
+                              expression
                                 Texp_ident "Stdlib!.-"
                               [
                                 <arg>
                                   Nolabel
-                                  expression 
+                                  expression
                                     Texp_ident "n"
                                 <arg>
                                   Nolabel
-                                  expression 
+                                  expression
                                     Texp_constant Const_int 2
                               ]
                         ]

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -89,21 +89,12 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def_rec>
         pattern
           Tpat_var "fib"
-<<<<<<< HEAD
           value_mode global,many,portable,unyielding,stateful,internal;imply(unique,uncontended,read_write)(modevar#3[aliased,contended,immutable .. unique,uncontended,read_write])
-        expression 
+        expression
           Texp_function
           alloc_mode global,many,portable,unyielding,stateful,internal;id(modevar#9[aliased,contended,immutable .. unique,uncontended,read_write])
           []
-          Tfunction_cases 
-=======
-          value_mode global,many,portable,unyielding,stateful,internal;imply(unique,uncontended,read_write)(modevar#1[aliased,contended,immutable .. unique,uncontended,read_write])
-        expression
-          Texp_function
-          alloc_mode global,many,portable,unyielding,stateful,internal;id(modevar#7[aliased,contended,immutable .. unique,uncontended,read_write])
-          []
           Tfunction_cases
->>>>>>> 6206867253 (add externality modal axis)
           alloc_mode global,many,nonportable,unyielding,stateful,internal;aliased,uncontended,read_write
           value
             [
@@ -120,11 +111,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                 pattern
                   Tpat_var "n"
                   value_mode global,many,portable,unyielding,stateless,external_;unique,uncontended,read_write
-<<<<<<< HEAD
-                expression 
-=======
                 expression
->>>>>>> 6206867253 (add externality modal axis)
                   Texp_apply
                   apply_mode Tail
                   locality_mode global

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -958,9 +958,9 @@ let (~x:x0, ~s, ~(y:int), ..) : (x:int * s:string * y:int * string) =
    (~x: 1, ~s: "a", ~y: 2, "ignore me")
 
 [%%expect{|
-val x0 : int @@ stateless = 1
+val x0 : int @@ stateless external_ = 1
 val s : string @@ stateless = "a"
-val y : int @@ stateless = 2
+val y : int @@ stateless external_ = 2
 |}]
 
 module M : sig
@@ -996,9 +996,9 @@ let f ((~(x:int),y) : (x:int * int)) : int = x + y
 
 [%%expect{|
 val foo : 'a -> (unit -> 'b) -> (unit -> 'b) -> 'b = <fun>
-val x : int @@ stateless = 1
+val x : int @@ stateless external_ = 1
 val y : int = 2
-val x : int @@ stateless = 1
+val x : int @@ stateless external_ = 1
 val y : int = 2
 val f : (foo:int * bar:int) -> int = <fun>
 val f : (x:int * int) -> int = <fun>

--- a/testsuite/tests/ppx-empty-cases/test.compilers.reference
+++ b/testsuite/tests/ppx-empty-cases/test.compilers.reference
@@ -3,35 +3,35 @@
     (empty_cases_returning_string/275 =
        (function {nlocal = 0} param/277
          (raise
-           (makeblock 0 (getpredef Match_failure/42!!) [0: "test.ml" 28 50])))
+           (makeblock 0 (getpredef Match_failure/43!!) [0: "test.ml" 28 50])))
      empty_cases_returning_float64/278 =
        (function {nlocal = 0} param/280 : unboxed_float
          (raise
-           (makeblock 0 (getpredef Match_failure/42!!) [0: "test.ml" 29 50])))
+           (makeblock 0 (getpredef Match_failure/43!!) [0: "test.ml" 29 50])))
      empty_cases_accepting_string/281 =
        (function {nlocal = 0} param/283
          (raise
-           (makeblock 0 (getpredef Match_failure/42!!) [0: "test.ml" 30 50])))
+           (makeblock 0 (getpredef Match_failure/43!!) [0: "test.ml" 30 50])))
      empty_cases_accepting_float64/284 =
        (function {nlocal = 0} param/286[unboxed_float]
          (raise
-           (makeblock 0 (getpredef Match_failure/42!!) [0: "test.ml" 31 50])))
+           (makeblock 0 (getpredef Match_failure/43!!) [0: "test.ml" 31 50])))
      non_empty_cases_returning_string/287 =
        (function {nlocal = 0} param/289
          (raise
-           (makeblock 0 (getpredef Assert_failure/52!!) [0: "test.ml" 32 68])))
+           (makeblock 0 (getpredef Assert_failure/53!!) [0: "test.ml" 32 68])))
      non_empty_cases_returning_float64/290 =
        (function {nlocal = 0} param/292 : unboxed_float
          (raise
-           (makeblock 0 (getpredef Assert_failure/52!!) [0: "test.ml" 33 68])))
+           (makeblock 0 (getpredef Assert_failure/53!!) [0: "test.ml" 33 68])))
      non_empty_cases_accepting_string/293 =
        (function {nlocal = 0} param/295
          (raise
-           (makeblock 0 (getpredef Assert_failure/52!!) [0: "test.ml" 34 68])))
+           (makeblock 0 (getpredef Assert_failure/53!!) [0: "test.ml" 34 68])))
      non_empty_cases_accepting_float64/296 =
        (function {nlocal = 0} param/298[unboxed_float]
          (raise
-           (makeblock 0 (getpredef Assert_failure/52!!) [0: "test.ml" 35 68]))))
+           (makeblock 0 (getpredef Assert_failure/53!!) [0: "test.ml" 35 68]))))
     (makeblock 0 empty_cases_returning_string/275
       empty_cases_returning_float64/278 empty_cases_accepting_string/281
       empty_cases_accepting_float64/284 non_empty_cases_returning_string/287

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -216,7 +216,7 @@ Error: The layout of type "a" is value
 type a : value mod global aliased many immutable stateless external_ unyielding non_float
 type b : value mod local unique once contended nonportable internal = a
 [%%expect{|
-type a : immediate
+type a : immediate64 mod external_
 type b = a
 |}]
 
@@ -307,7 +307,7 @@ type d : float64 = c
 [%%expect{|
 type a = float#
 type b = a
-type c : float64 mod everything
+type c : float64 mod global aliased many stateless immutable external_
 type d = c
 |}]
 
@@ -318,7 +318,7 @@ type d : float32 = c
 [%%expect{|
 type a = float32#
 type b = a
-type c : float32 mod everything
+type c : float32 mod global aliased many stateless immutable external_
 type d = c
 |}]
 
@@ -488,13 +488,7 @@ Error: The kind of type "t_value" is value
 
 type t : any mod portable = t_value
 [%%expect{|
-Line 1, characters 0-35:
-1 | type t : any mod portable = t_value
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t_value" is value
-         because of the definition of t_value at line 1, characters 0-20.
-       But the kind of type "t_value" must be a subkind of any mod portable
-         because of the definition of t at line 1, characters 0-35.
+type t = t_value
 |}]
 
 type t : any mod external_ = t_value
@@ -1285,7 +1279,7 @@ type ('a : bits32 mod aliased) t = ('a : any mod global)
 type ('a : value mod global aliased) t = 'a
 type ('a : immediate) t = 'a
 type ('a : immediate) t = 'a
-type ('a : immediate) t = 'a
+type ('a : immediate64 mod external_) t = 'a
 type 'a t = 'a
 type 'a t = 'a
 type ('a : bits32 mod global aliased) t = 'a

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -216,7 +216,7 @@ Error: The layout of type "a" is value
 type a : value mod global aliased many immutable stateless external_ unyielding non_float
 type b : value mod local unique once contended nonportable internal = a
 [%%expect{|
-type a : immediate64 mod external_
+type a : immediate
 type b = a
 |}]
 
@@ -307,7 +307,7 @@ type d : float64 = c
 [%%expect{|
 type a = float#
 type b = a
-type c : float64 mod global aliased many stateless immutable external_
+type c : float64 mod everything
 type d = c
 |}]
 
@@ -318,7 +318,7 @@ type d : float32 = c
 [%%expect{|
 type a = float32#
 type b = a
-type c : float32 mod global aliased many stateless immutable external_
+type c : float32 mod everything
 type d = c
 |}]
 
@@ -488,7 +488,13 @@ Error: The kind of type "t_value" is value
 
 type t : any mod portable = t_value
 [%%expect{|
-type t = t_value
+Line 1, characters 0-35:
+1 | type t : any mod portable = t_value
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t_value" is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type "t_value" must be a subkind of any mod portable
+         because of the definition of t at line 1, characters 0-35.
 |}]
 
 type t : any mod external_ = t_value
@@ -1279,7 +1285,7 @@ type ('a : bits32 mod aliased) t = ('a : any mod global)
 type ('a : value mod global aliased) t = 'a
 type ('a : immediate) t = 'a
 type ('a : immediate) t = 'a
-type ('a : immediate64 mod external_) t = 'a
+type ('a : immediate) t = 'a
 type 'a t = 'a
 type 'a t = 'a
 type ('a : bits32 mod global aliased) t = 'a

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -280,7 +280,13 @@ type d : immediate = c
 type a : immediate
 type b = a
 type c : immediate
-type d = c
+Line 4, characters 0-22:
+4 | type d : immediate = c
+    ^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "c" is immediate
+         because of the definition of c at line 3, characters 0-89.
+       But the kind of type "c" must be a subkind of immediate
+         because of the definition of d at line 4, characters 0-22.
 |}]
 
 type a : immediate64

--- a/testsuite/tests/typing-modes/externality.ml
+++ b/testsuite/tests/typing-modes/externality.ml
@@ -1,0 +1,291 @@
+(* TEST
+ include stdlib_upstream_compatible;
+ expect;
+*)
+
+module Float_u = Stdlib_upstream_compatible.Float_u
+
+type t : float64 = float#
+[%%expect {|
+module Float_u = Stdlib_upstream_compatible.Float_u
+type t = float#
+|}]
+
+
+type t : bits64 = int64#
+[%%expect {|
+type t = int64#
+|}]
+
+
+let immediate_is_external () =
+  let _x @ external_ = 3 in
+  let _y @ external_ = 'a' in
+  ()
+[%%expect{|
+val immediate_is_external : unit -> unit = <fun>
+|}]
+
+let immediate_is_external64 () =
+  let _x @ external64 = 'a' in
+  let _y @ external64 = 3 in
+  let _z @ external64 = None in
+  ()
+[%%expect{|
+val immediate_is_external64 : unit -> unit = <fun>
+|}]
+
+
+module F (M : sig type t : immediate64 val f : unit -> t end) = struct
+  let u =
+    let _ : M.t @ external_ = M.f () in
+    ()
+end
+[%%expect {|
+Line 3, characters 30-36:
+3 |     let _ : M.t @ external_ = M.f () in
+                                  ^^^^^^
+Error: This value is "external64" but expected to be "external_".
+|}]
+
+module F (M : sig type t : immediate64 val f : unit -> t end) = struct
+  let u =
+    let _ : M.t @ external64 = M.f () in
+    ()
+end
+[%%expect {|
+module F :
+  functor (M : sig type t : immediate64 val f : unit -> t end) ->
+    sig val u : unit end
+|}]
+
+let none_is_external () =
+  let _x @ external_ = None in
+  ()
+[%%expect {|
+val none_is_external : unit -> unit = <fun>
+|}]
+
+let empty_list_is_external () =
+  let _x @ external_ = [] in
+  ()
+[%%expect {|
+val empty_list_is_external : unit -> unit = <fun>
+|}]
+
+
+let some_is_not_external () =
+  let _y @ external_ = Some 3 in
+  ()
+[%%expect {|
+Line 2, characters 23-29:
+2 |   let _y @ external_ = Some 3 in
+                           ^^^^^^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+let float_is_not_external x =
+  let u : float @ external_ = (3.0 +. x) in
+  u
+[%%expect{|
+Line 2, characters 30-40:
+2 |   let u : float @ external_ = (3.0 +. x) in
+                                  ^^^^^^^^^^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+
+type t = {a : int; b : float}
+let record_is_not_external () =
+  let _y @ external_ = {a = 3; b = 4.0} in
+  ()
+[%%expect{|
+type t = { a : int; b : float; }
+Line 3, characters 23-39:
+3 |   let _y @ external_ = {a = 3; b = 4.0} in
+                           ^^^^^^^^^^^^^^^^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+let cannot_pass_internal_to_external =
+  let foo (x : 'a @ external_) = () in
+  let bar (x : 'a @ internal) = foo x in
+  ()
+[%%expect{|
+Line 3, characters 36-37:
+3 |   let bar (x : 'a @ internal) = foo x in
+                                        ^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+let cannot_pass_internal_to_external64 =
+  let foo (x : 'a @ external64) = () in
+  let bar (x : 'a @ internal) = foo x in
+  ()
+
+[%%expect{|
+Line 3, characters 36-37:
+3 |   let bar (x : 'a @ internal) = foo x in
+                                        ^
+Error: This value is "internal" but expected to be "external64".
+|}]
+
+
+
+(*
+   The code below is the expected behavior. For future axes where
+   the legacy mode is top, you are allowed to do this. Similarly you can write a
+   nonportable thing into a portable record.  You're just prevented from
+   creating a portable record with a mutable field not marked as @@ portable.
+ *)
+
+type 'a t = {mutable f : 'a}
+let foo (t : 'a t @ external_) (x : 'a @ internal) =
+  t.f <- x
+[%%expect{|
+type 'a t = { mutable f : 'a; }
+val foo : 'a t -> 'a -> unit = <fun>
+|}]
+
+(* CR jcutler: In the above type's case, creating an @external_ record of this type
+   should be disallowed. Because there is not currently a way to create external records
+(in this PR), we cannot test this. When malloc is introduced, add a test for this. *)
+
+let foo (t : 'a ref @ external_) (x : 'a @ internal) =
+  t := x
+[%%expect{|
+val foo : 'a ref -> 'a -> unit = <fun>
+|}]
+
+let foo (t : 'a array @ external_) (x : 'a @ internal) =
+  t.(0) <- x
+[%%expect{|
+val foo : 'a array -> 'a -> unit = <fun>
+|}]
+
+type 'a t = {mutable f : 'a @@ external_}
+let bar (t : 'a t @ external_) (x : 'a @ internal) =
+  t.f <- x
+[%%expect{|
+type 'a t = { mutable f : 'a @@ external_; }
+Line 3, characters 9-10:
+3 |   t.f <- x
+             ^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+
+(* In the above case, creating an @external_ record of this type
+   should be *allowed*. *)
+
+type 'a external_ = { ext : 'a @@ external_ }
+let into_external () =
+  let _ : int option external_ = {ext = Some 3} in
+  ()
+[%%expect {|
+type 'a external_ = { ext : 'a @@ external_; }
+Line 3, characters 40-46:
+3 |   let _ : int option external_ = {ext = Some 3} in
+                                            ^^^^^^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+let into_external () =
+  let _ : int external_ = {ext = 3} in
+  ()
+[%%expect {|
+val into_external : unit -> unit = <fun>
+|}]
+
+
+let f (x : string @ internal) : #(string * string) @ external_ = #(x, x)
+[%%expect {|
+Line 1, characters 67-68:
+1 | let f (x : string @ internal) : #(string * string) @ external_ = #(x, x)
+                                                                       ^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+let f (x : string @ external_) : #(string * string) @ external_ = #(x, x)
+
+[%%expect {|
+val f : string -> #(string * string) = <fun>
+|}]
+
+let f (x : int @ internal) : #(int * int) @ external_ = #(x, x)
+[%%expect {|
+val f : int -> #(int * int) = <fun>
+|}]
+
+type t = #{x : int; y : string @@ external_}
+let f (x : int) (y : string @ internal) = #{x;y}
+[%%expect {|
+type t = #{ x : int; y : string @@ external_; }
+Line 2, characters 46-47:
+2 | let f (x : int) (y : string @ internal) = #{x;y}
+                                                  ^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+type t = #{x : int; y : string }
+let f (x : int) (y : string @ internal) : t @ external_ = #{x;y}
+[%%expect {|
+type t = #{ x : int; y : string; }
+Line 2, characters 62-63:
+2 | let f (x : int) (y : string @ internal) : t @ external_ = #{x;y}
+                                                                  ^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+
+type t = #{x : int; y : string }
+let f (x : int) (y : string @ external_) : t @ external_ = #{x;y}
+[%%expect {|
+type t = #{ x : int; y : string; }
+val f : int -> string -> t = <fun>
+|}]
+
+(* CR jcutler: When we support externally allocating functions, write a test to show that
+You can only allocate functions that don't close over internals.
+*)
+
+(* Byte externality vs externality. This is a really bad error mesage, by design. We
+expect users to never write byte_external, and indeed not be aware of its existence.
+In the future when bytecode is no longer supported and byte_external is deleted,
+this evil will be banished.
+*)
+let add_three  (x : float# @ byte_external) : float# @ byte_external = Float_u.add #3.0 x
+[%%expect {|
+Line 1, characters 71-89:
+1 | let add_three  (x : float# @ byte_external) : float# @ byte_external = Float_u.add #3.0 x
+                                                                           ^^^^^^^^^^^^^^^^^^
+Error: This value is "external_" but expected to be "external_".
+|}]
+
+let add_three (x : int @ byte_external) : int @ byte_external = 3 + x
+[%%expect {|
+val add_three : int -> int = <fun>
+|}]
+
+
+let is_not_byte_external =
+  let _ @ byte_external = #(3,4) in
+  ()
+[%%expect {|
+Line 2, characters 26-32:
+2 |   let _ @ byte_external = #(3,4) in
+                              ^^^^^^
+Error: This value is "external_" but expected to be "external_".
+|}]
+
+type t = #{x : int; y : int}
+let is_not_byte_external2 (x @ byte_external) (y @ byte_external)=
+  let z @ byte_external = #{x ; y} in
+  z
+[%%expect {|
+type t = #{ x : int; y : int; }
+Line 3, characters 26-34:
+3 |   let z @ byte_external = #{x ; y} in
+                              ^^^^^^^^
+Error: This value is "external_" but expected to be "external_".
+|}]

--- a/testsuite/tests/typing-modes/externality.ml
+++ b/testsuite/tests/typing-modes/externality.ml
@@ -11,13 +11,6 @@ module Float_u = Stdlib_upstream_compatible.Float_u
 type t = float#
 |}]
 
-
-type t : bits64 = int64#
-[%%expect {|
-type t = int64#
-|}]
-
-
 let immediate_is_external () =
   let _x @ external_ = 3 in
   let _y @ external_ = 'a' in
@@ -137,6 +130,7 @@ Error: This value is "internal" but expected to be "external64".
    the legacy mode is top, you are allowed to do this. Similarly you can write a
    nonportable thing into a portable record.  You're just prevented from
    creating a portable record with a mutable field not marked as @@ portable.
+   (see tests in [malloc.ml])
  *)
 
 type 'a t = {mutable f : 'a}
@@ -146,10 +140,6 @@ let foo (t : 'a t @ external_) (x : 'a @ internal) =
 type 'a t = { mutable f : 'a; }
 val foo : 'a t -> 'a -> unit = <fun>
 |}]
-
-(* CR jcutler: In the above type's case, creating an @external_ record of this type
-   should be disallowed. Because there is not currently a way to create external records
-(in this PR), we cannot test this. When malloc is introduced, add a test for this. *)
 
 let foo (t : 'a ref @ external_) (x : 'a @ internal) =
   t := x

--- a/testsuite/tests/typing-modes/malloc.ml
+++ b/testsuite/tests/typing-modes/malloc.ml
@@ -1,0 +1,370 @@
+(* TEST
+ expect;
+*)
+
+type t : bits64 = int mallocd
+[%%expect {|
+type t = int mallocd
+|}]
+
+type t : bits64 mod external_ = int mallocd
+[%%expect {|
+Line 1, characters 0-43:
+1 | type t : bits64 mod external_ = int mallocd
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int mallocd" is bits64
+         because it is the primitive type mallocd.
+       But the kind of type "int mallocd" must be a subkind of
+           bits64 mod external_
+         because of the definition of t at line 1, characters 0-43.
+|}]
+
+type t = float# mallocd
+[%%expect {|
+Line 1, characters 9-15:
+1 | type t = float# mallocd
+             ^^^^^^
+Error: This type "float#" should be an instance of type "('a : value_or_null)"
+       The layout of float# is float64
+         because it is the unboxed version of the primitive type float.
+       But the layout of float# must be a sublayout of value
+         because the type argument of mallocd has layout value_or_null.
+|}]
+
+type t = int or_null mallocd
+[%%expect {|
+type t = int or_null mallocd
+|}]
+
+let foo () = malloc_ (1,2)
+[%%expect {|
+val foo : unit -> (int * int) mallocd = <fun>
+|}]
+
+let foo () = malloc_ (1,"Asdf")
+[%%expect {|
+val foo : unit -> (int * string) mallocd = <fun>
+|}]
+
+let foo (x @ external_) = malloc_ (x,1)
+[%%expect {|
+val foo : 'a -> ('a * int) mallocd = <fun>
+|}]
+
+let asdf (x @ internal) = malloc_ (x,2)
+[%%expect {|
+Line 1, characters 35-36:
+1 | let asdf (x @ internal) = malloc_ (x,2)
+                                       ^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+type t = {x : int; y : int}
+let f () = malloc_ {x = 3; y = 4}
+[%%expect{|
+type t = { x : int; y : int; }
+val f : unit -> t mallocd = <fun>
+|}]
+
+let f (x @ external_) = malloc_ {x = x; y = x}
+[%%expect{|
+val f : int -> t mallocd = <fun>
+|}]
+
+type 'a t = {x : 'a ; y : 'a option mallocd }
+let f x =
+  let y = malloc_ (Some x) in
+  malloc_ {x;y}
+[%%expect {|
+type 'a t = { x : 'a; y : 'a option mallocd; }
+val f : 'a -> 'a t mallocd = <fun>
+|}]
+
+
+
+
+let foo () = malloc_ []
+[%%expect {|
+Line 1, characters 21-23:
+1 | let foo () = malloc_ []
+                         ^^
+Error: This expression is not an allocation site.
+|}]
+
+let foo () = malloc_ [1]
+[%%expect {|
+val foo : unit -> int list mallocd = <fun>
+|}]
+
+let foo () = malloc_ [1;2;3]
+[%%expect {|
+Line 1, characters 24-28:
+1 | let foo () = malloc_ [1;2;3]
+                            ^^^^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+let foo (x @ external_) (xs @ external_) =
+  malloc_ (x :: xs)
+[%%expect {|
+val foo : 'a -> 'a list -> 'a list mallocd = <fun>
+|}]
+
+let foo (x @ internal) (xs @ internal) =
+  malloc_ (x :: xs)
+[%%expect {|
+Line 2, characters 11-12:
+2 |   malloc_ (x :: xs)
+               ^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+let foo (x @ external_) (xs @ internal) =
+  malloc_ (x :: xs)
+[%%expect {|
+Line 2, characters 16-18:
+2 |   malloc_ (x :: xs)
+                    ^^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+
+type t1 = Foo of int | Bar
+type t2 = Baz of t1
+
+let f () = malloc_ (Baz (Foo 3))
+[%%expect {|
+type t1 = Foo of int | Bar
+type t2 = Baz of t1
+Line 4, characters 24-31:
+4 | let f () = malloc_ (Baz (Foo 3))
+                            ^^^^^^^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+
+
+let foo1 () = malloc_ [|1;2;3|]
+[%%expect {|
+Line 1, characters 22-31:
+1 | let foo1 () = malloc_ [|1;2;3|]
+                          ^^^^^^^^^
+Error: Externally allocating arrays is not supported yet.
+|}]
+
+
+
+(* CR external-mode: The following error correctly catches an error: to malloc a
+   record with mutable fields, all mutable fields must be marked @@ external_.
+   However, it doesn't really explain that this is *why*, and worse, it's
+   actively misleading. High priority to fix this. *)
+type t = {mutable x : string; y : bool}
+let bar1 x y = malloc_ {x;y}
+[%%expect {|
+type t = { mutable x : string; y : bool; }
+Line 2, characters 23-28:
+2 | let bar1 x y = malloc_ {x;y}
+                           ^^^^^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+type t = {mutable x : string @@ external_ ; y : bool}
+let bar2 x y = malloc_ {x;y}
+[%%expect {|
+type t = { mutable x : string @@ external_; y : bool; }
+val bar2 : string -> bool -> t mallocd = <fun>
+|}]
+
+
+
+type 'a t = Foo | Bar of 'a | Baz of 'a * string
+let baz1 () = malloc_ Foo
+[%%expect {|
+type 'a t = Foo | Bar of 'a | Baz of 'a * string
+Line 2, characters 22-25:
+2 | let baz1 () = malloc_ Foo
+                          ^^^
+Error: This expression is not an allocation site.
+|}]
+
+let baz2 () = malloc_ (Bar 1)
+[%%expect {|
+val baz2 : unit -> int t mallocd = <fun>
+|}]
+
+let baz3 () = malloc_ (Bar "asdf")
+[%%expect {|
+val baz3 : unit -> string t mallocd = <fun>
+|}]
+
+let baz4 (x @ external_) = malloc_ (Baz (1,x))
+[%%expect {|
+val baz4 : string -> int t mallocd = <fun>
+|}]
+
+type 'a t = FooBar of {mutable x : 'a @@ external_ ; mutable y : 'a @@ external_}
+let foobar (x @ external_) (y @ external_ ) = malloc_ (FooBar {x ; y})
+[%%expect {|
+type 'a t =
+    FooBar of { mutable x : 'a @@ external_; mutable y : 'a @@ external_; }
+val foobar : 'a -> 'a -> 'a t mallocd = <fun>
+|}]
+
+type 'a r = {mutable x : 'a @@ external_ ; mutable y : 'a @@ external_}
+type 'a t = FooBar of 'a
+let flop (x @ external_) (y @ external_ ) = malloc_ {x ; y}
+[%%expect {|
+type 'a r = { mutable x : 'a @@ external_; mutable y : 'a @@ external_; }
+type 'a t = FooBar of 'a
+val flop : 'a -> 'a -> 'a r mallocd = <fun>
+|}]
+let fleep (x @ external_) (y @ external_ ) = malloc_ (FooBar {x ; y})
+[%%expect {|
+Line 1, characters 61-68:
+1 | let fleep (x @ external_) (y @ external_ ) = malloc_ (FooBar {x ; y})
+                                                                 ^^^^^^^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+type 'a t = FooBar of {mutable x : 'a ; mutable y : 'a @@ external_}
+let foobar (x @ external_) (y @ external_ ) = malloc_ (FooBar {x ; y})
+[%%expect {|
+type 'a t = FooBar of { mutable x : 'a; mutable y : 'a @@ external_; }
+Line 2, characters 62-69:
+2 | let foobar (x @ external_) (y @ external_ ) = malloc_ (FooBar {x ; y})
+                                                                  ^^^^^^^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+let blah () = malloc_ (lazy (2 + 2))
+[%%expect {|
+Line 1, characters 22-36:
+1 | let blah () = malloc_ (lazy (2 + 2))
+                          ^^^^^^^^^^^^^^
+Error: Externally allocating lazy expressions is not supported yet.
+|}]
+
+let blargh () = malloc_ ((fun x -> x + 1) 2)
+[%%expect {|
+Line 1, characters 24-44:
+1 | let blargh () = malloc_ ((fun x -> x + 1) 2)
+                            ^^^^^^^^^^^^^^^^^^^^
+Error: This expression is not an allocation site.
+|}]
+
+let floop () = malloc_ (fun x -> x + 1)
+[%%expect {|
+Line 1, characters 23-39:
+1 | let floop () = malloc_ (fun x -> x + 1)
+                           ^^^^^^^^^^^^^^^^
+Error: Externally allocating functions is not supported yet.
+|}]
+
+let f () = malloc_ `Apple
+[%%expect {|
+Line 1, characters 19-25:
+1 | let f () = malloc_ `Apple
+                       ^^^^^^
+Error: This expression is not an allocation site.
+|}]
+
+let f () = malloc_ (`Apple 5)
+[%%expect {|
+val f : unit -> [> `Apple of int ] mallocd = <fun>
+|}]
+
+let f () = malloc_ (`Apple (1,2,3))
+[%%expect {|
+Line 1, characters 27-34:
+1 | let f () = malloc_ (`Apple (1,2,3))
+                               ^^^^^^^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+let f () = malloc_ (`Apple {a = 1; b = 3})
+[%%expect {|
+Line 1, characters 28-29:
+1 | let f () = malloc_ (`Apple {a = 1; b = 3})
+                                ^
+Error: Unbound record field "a"
+|}]
+
+
+let f () = malloc_ #(1,2)
+[%%expect {|
+Line 1, characters 19-25:
+1 | let f () = malloc_ #(1,2)
+                       ^^^^^^
+Error: This expression is not an allocation site.
+|}]
+
+
+type t = #{x : int; y : char}
+let f () = malloc_ #{x = 3; y = 'z'}
+[%%expect {|
+type t = #{ x : int; y : char; }
+Line 2, characters 19-36:
+2 | let f () = malloc_ #{x = 3; y = 'z'}
+                       ^^^^^^^^^^^^^^^^^
+Error: This expression is not an allocation site.
+|}]
+
+let obj () = malloc_ (object method x () = 42 end)
+[%%expect{|
+Line 1, characters 21-50:
+1 | let obj () = malloc_ (object method x () = 42 end)
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Externally allocating objects is not supported yet.
+|}]
+
+
+exception Exn of int
+let exn () = malloc_ (Exn 2)
+[%%expect{|
+exception Exn of int
+val exn : unit -> exn mallocd = <fun>
+|}]
+
+let exn () = malloc_ (raise (Exn 2))
+[%%expect{|
+Line 1, characters 21-36:
+1 | let exn () = malloc_ (raise (Exn 2))
+                         ^^^^^^^^^^^^^^^
+Error: This expression is not an allocation site.
+|}]
+
+
+let flarb () =
+  malloc_ (1,
+    let f x = (x,x) in
+    let (a,b) = f 2 in
+    a
+  )
+[%%expect {|
+val flarb : unit -> (int * int) mallocd = <fun>
+|}]
+
+let fleep () = malloc_ (1,(2,3))
+[%%expect{|
+Line 1, characters 26-31:
+1 | let fleep () = malloc_ (1,(2,3))
+                              ^^^^^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+type 'a t = Foo of 'a
+let glorb1 () = malloc_ (Foo (1,2))
+[%%expect {|
+type 'a t = Foo of 'a
+Line 2, characters 29-34:
+2 | let glorb1 () = malloc_ (Foo (1,2))
+                                 ^^^^^
+Error: This value is "internal" but expected to be "external_".
+|}]
+
+type 'a t = Foo of 'a * 'a
+let glorb2 () = malloc_ (Foo (1,2))
+[%%expect {|
+type 'a t = Foo of 'a * 'a
+val glorb2 : unit -> int t mallocd = <fun>
+|}]

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -100,7 +100,7 @@ module (M @ uncontended) = struct
     let x @ contended = "hello"
 end
 [%%expect{|
-module M : sig val x : string @@ contended end @@ stateless
+module M : sig val x : string @@ contended external_ end @@ stateless
 |}]
 
 (* Testing the defaulting behaviour.
@@ -694,14 +694,14 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val t : [> `Foo ] @@ stateless nonportable end (* at nonportable *)
+         sig val t : [> `Foo ] @@ stateless nonportable external_ end (* at nonportable *)
        is not included in
          sig
            val t : [ `Bar of 'a -> 'a | `Baz of string ref | `Foo ] @@
              portable
          end (* at nonportable *)
        Values do not match:
-         val t : [> `Foo ] @@ stateless nonportable (* in a structure at nonportable *)
+         val t : [> `Foo ] @@ stateless nonportable external_ (* in a structure at nonportable *)
        is not included in
          val t : [ `Bar of 'a -> 'a | `Baz of string ref | `Foo ] @@ portable (* in a structure at nonportable *)
        The first is "nonportable" but the second is "portable".

--- a/testsuite/tests/typing-unboxed-types/test.ml
+++ b/testsuite/tests/typing-unboxed-types/test.ml
@@ -544,12 +544,19 @@ val g : f array =
 val h : f = #{field = []}
 |}];;
 
+(* CR jcutler: This test needs to be fixed before the external mode can be merged.*)
 (* Using [@@immediate] information (GPR#1469) *)
 type 'a t [@@immediate];;
 type u = U : 'a t -> u [@@unboxed];;
 [%%expect{|
 type 'a t : immediate
-type u = U : 'a t -> u [@@unboxed]
+Line 2, characters 0-34:
+2 | type u = U : 'a t -> u [@@unboxed];;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because
+       it might contain both float and non-float values,
+       depending on the instantiation of the existential variable "'a".
+       You should annotate it with "[@@ocaml.boxed]".
 |}];;
 
 (* This could not be accepted without using a fixpoint to check unboxed declarations

--- a/tools/debug_printers.ml
+++ b/tools/debug_printers.ml
@@ -25,3 +25,5 @@ let mod_bounds ppf m = Types.Jkind_mod_bounds.debug_print ppf m
 let with_bounds ppf w = Jkind.With_bounds.debug_print ppf w
 let with_bounds_types ppf w = Jkind.With_bounds.debug_print_types ppf w
 let modalities = Mode.Modality.Value.Const.print
+let mode ppf m = Mode.Value.print ~verbose:true () ppf m
+let mode_alloc ppf m = Mode.Alloc.print ~verbose:true () ppf m

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2620,9 +2620,11 @@ let constrain_type_jkind env ty jkind =
 let () =
   Env.constrain_type_jkind := constrain_type_jkind
 
-let check_type_externality env ty ext =
+let check_type_externality env ty externality =
   let upper_bound =
-    Jkind.set_externality_upper_bound (Jkind.Builtin.any ~why:Dummy_jkind) ext
+    Jkind.set_externality_upper_bound
+      (Jkind.Builtin.any ~why:Dummy_jkind)
+      externality
   in
   match check_type_jkind env ty upper_bound with
   | Ok () -> true
@@ -2707,7 +2709,7 @@ let check_and_update_generalized_ty_jkind ?name ~loc env ty =
          might turn out later to be value. This is the conservative choice. *)
       let jkind_of_type = type_jkind_purely_if_principal env in
       let ext = Jkind.get_externality_upper_bound ~jkind_of_type jkind in
-      Jkind_axis.Externality.le ext External64 &&
+      Mode.Externality.Const.le ext External64 &&
       match Jkind.get_layout jkind with
       | Some (Base Value) | None -> true
       | _ -> false
@@ -5078,6 +5080,7 @@ let mode_crossing_structure_memaddr =
       portability = Portable;
       yielding = Unyielding;
       statefulness = Stateless;
+      externality = Internal;
   }}
 
 (** The mode crossing of a functor. *)
@@ -5094,6 +5097,7 @@ let mode_crossing_functor =
       portability = Nonportable;
       yielding = Yielding;
       statefulness = Stateful;
+      externality = Internal;
   }}
 
 (** The mode crossing of any module. *)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -663,7 +663,7 @@ val constrain_type_jkind :
    Potentially cheaper than just calling [type_jkind], because this can stop
    expansion once it succeeds. *)
 val check_type_externality :
-  Env.t -> type_expr -> Jkind_axis.Externality.t -> bool
+  Env.t -> type_expr -> Jkind_mod_bounds.Externality.t -> bool
 
 (* Check whether a type's nullability is less than some target.
    Uses get_nullability which is potentially cheaper than calling type_jkind

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -4813,6 +4813,8 @@ let report_lookup_error _loc env ppf = function
         | Error (Statefulness, {left; right}) ->
           asprintf "%a" Mode.Statefulness.Const.print left,
           asprintf "is %a" Mode.Statefulness.Const.print right
+        | Error (Externality, _) ->
+            Misc.fatal_error "Externally-allocated closures are not supported."
       in
       let s, hint =
         match context with

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -258,6 +258,9 @@ let zap_axis_to_floor
   | Comonadic Statefulness ->
       Mode.Statefulness.zap_to_floor
         (Mode.Value.proj_comonadic Statefulness m)
+  | Comonadic Externality ->
+      Mode.Externality.zap_to_floor
+        (Mode.Value.proj_comonadic Externality m)
   | Monadic Uniqueness ->
       Mode.Uniqueness.zap_to_floor (Mode.Value.proj_monadic Uniqueness m)
   | Monadic Contention ->
@@ -279,6 +282,8 @@ let zap_axis_to_ceil
       Mode.Yielding.zap_to_ceil (Mode.Value.proj_comonadic Yielding m)
   | Comonadic Statefulness ->
       Mode.Statefulness.zap_to_ceil (Mode.Value.proj_comonadic Statefulness m)
+  | Comonadic Externality->
+      Mode.Externality.zap_to_ceil (Mode.Value.proj_comonadic Externality m)
   | Monadic Uniqueness ->
       Mode.Uniqueness.zap_to_ceil (Mode.Value.proj_monadic Uniqueness m)
   | Monadic Contention ->

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2451,7 +2451,8 @@ let for_or_null_argument ident =
       ~yielding:Yielding.Const.max ~uniqueness:Uniqueness.Const_op.max
       ~contention:Contention.Const_op.max ~statefulness:Statefulness.Const.max
       ~visibility:Visibility.Const_op.max ~externality:Externality.Const.max
-      ~nullability:Nullability.Non_null ~separability:Separability.Non_float
+      ~nullability:Nullability.Non_null
+      ~separability:Separability.Maybe_separable
   in
   fresh_jkind
     { layout = Sort (Base Value); mod_bounds; with_bounds = No_with_bounds }

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1498,7 +1498,6 @@ module Const = struct
 
     (* CR layouts v3: change to [Maybe_null] when
        [or_null array]s are implemented. *)
-    (* CR jcutler: ensure all the kind/kind_of_unboxed pairs have this pattern.*)
     let float64 =
       { jkind =
           mk_jkind (Base Float64) ~mode_crossing:false ~nullability:Non_null

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1310,7 +1310,6 @@ module Const = struct
        types that "cross everything" should cross at external or byte_external *)
     let mk_jkind ~mode_crossing ~nullability ~separability ~externality
         (layout : Layout.Const.t) =
-      let id x = x in
       let mod_bounds =
         (match mode_crossing with
         | true -> Mod_bounds.min

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1310,6 +1310,7 @@ module Const = struct
        types that "cross everything" should cross at external or byte_external *)
     let mk_jkind ~mode_crossing ~nullability ~separability ~externality
         (layout : Layout.Const.t) =
+      let id x = x in
       let mod_bounds =
         (match mode_crossing with
         | true -> Mod_bounds.min
@@ -1497,6 +1498,7 @@ module Const = struct
 
     (* CR layouts v3: change to [Maybe_null] when
        [or_null array]s are implemented. *)
+    (* CR jcutler: ensure all the kind/kind_of_unboxed pairs have this pattern.*)
     let float64 =
       { jkind =
           mk_jkind (Base Float64) ~mode_crossing:false ~nullability:Non_null
@@ -2451,8 +2453,7 @@ let for_or_null_argument ident =
       ~yielding:Yielding.Const.max ~uniqueness:Uniqueness.Const_op.max
       ~contention:Contention.Const_op.max ~statefulness:Statefulness.Const.max
       ~visibility:Visibility.Const_op.max ~externality:Externality.Const.max
-      ~nullability:Nullability.Non_null
-      ~separability:Separability.Maybe_separable
+      ~nullability:Nullability.Non_null ~separability:Separability.Non_float
   in
   fresh_jkind
     { layout = Sort (Base Value); mod_bounds; with_bounds = No_with_bounds }
@@ -2694,7 +2695,6 @@ let to_unsafe_mode_crossing jkind =
 let all_except_externality =
   Axis_set.singleton (Modal (Comonadic Externality)) |> Axis_set.complement
 
-(* CR jcutler: can we get rid of this? *)
 let get_externality_upper_bound ~jkind_of_type jk =
   let ( ({ layout = _; mod_bounds; with_bounds = No_with_bounds } :
           (_ * allowed) jkind_desc),

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2694,6 +2694,7 @@ let to_unsafe_mode_crossing jkind =
 let all_except_externality =
   Axis_set.singleton (Modal (Comonadic Externality)) |> Axis_set.complement
 
+(* CR jcutler: can we get rid of this? *)
 let get_externality_upper_bound ~jkind_of_type jk =
   let ( ({ layout = _; mod_bounds; with_bounds = No_with_bounds } :
           (_ * allowed) jkind_desc),

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -351,7 +351,6 @@ module Layout = struct
     pp_element ~nested:false ppf layout
 end
 
-module Externality = Externality
 module Nullability = Nullability
 module Separability = Jkind_axis.Separability
 
@@ -415,7 +414,6 @@ let relevant_axes_of_modality ~relevant_for_shallow ~modality =
          mode-crossing. In the future, we may want to complexify the modal-kinds
          setup to allow for more mode-crossing in the presence of non-constant
          non-identity modalities. *)
-      | Nonmodal Externality -> true
       | Nonmodal Nullability -> (
         match relevant_for_shallow with
         | `Relevant -> true
@@ -514,7 +512,7 @@ module Mod_bounds = struct
             (visibility t2))
     @@ Sub_result.combine
          (axis_less_or_equal ~le:Externality.le
-            ~axis:(Pack (Nonmodal Externality)) (externality t1)
+            ~axis:(Pack (Modal (Comonadic Externality))) (externality t1)
             (externality t2))
     @@ Sub_result.combine
          (axis_less_or_equal ~le:Nullability.le
@@ -547,7 +545,7 @@ module Mod_bounds = struct
     | Modal (Comonadic Yielding) -> yielding t
     | Modal (Comonadic Statefulness) -> statefulness t
     | Modal (Monadic Visibility) -> visibility t
-    | Nonmodal Externality -> externality t
+    | Modal (Comonadic Externality) -> externality t
     | Nonmodal Nullability -> nullability t
     | Nonmodal Separability -> separability t
 
@@ -583,7 +581,7 @@ module Mod_bounds = struct
          (Modal (Monadic Visibility))
     |> add_if
          (Externality.le Externality.max (externality t))
-         (Nonmodal Externality)
+         (Modal (Comonadic Externality))
     |> add_if
          (Nullability.le Nullability.max (nullability t))
          (Nonmodal Nullability)
@@ -607,7 +605,8 @@ module Mod_bounds = struct
               linearity = linearity t;
               portability = portability t;
               yielding = yielding t;
-              statefulness = statefulness t
+              statefulness = statefulness t;
+              externality = externality t
             };
           monadic =
             { uniqueness = uniqueness t;
@@ -1063,7 +1062,8 @@ module Layout_and_axes = struct
                 ~statefulness:
                   (value_for_axis ~axis:(Modal (Comonadic Statefulness)))
                 ~visibility:(value_for_axis ~axis:(Modal (Monadic Visibility)))
-                ~externality:(value_for_axis ~axis:(Nonmodal Externality))
+                ~externality:
+                  (value_for_axis ~axis:(Modal (Comonadic Externality)))
                 ~nullability:(value_for_axis ~axis:(Nonmodal Nullability))
                 ~separability:(value_for_axis ~axis:(Nonmodal Separability))
             in
@@ -1305,7 +1305,10 @@ module Const = struct
         name : string
       }
 
-    let mk_jkind ~mode_crossing ~nullability ~separability
+    (* NB: mode_crossing = true does not imply anything about externality. We
+       always explicitly pass externality, since it is not always obvious if
+       types that "cross everything" should cross at external or byte_external *)
+    let mk_jkind ~mode_crossing ~nullability ~separability ~externality
         (layout : Layout.Const.t) =
       let mod_bounds =
         (match mode_crossing with
@@ -1313,20 +1316,21 @@ module Const = struct
         | false -> Mod_bounds.max)
         |> Mod_bounds.set_nullability nullability
         |> Mod_bounds.set_separability separability
+        |> Mod_bounds.set_externality externality
       in
       { layout; mod_bounds; with_bounds = No_with_bounds }
 
     let any =
       { jkind =
           mk_jkind Any ~mode_crossing:false ~nullability:Maybe_null
-            ~separability:Maybe_separable;
+            ~separability:Maybe_separable ~externality:Internal;
         name = "any"
       }
 
     let any_mod_everything =
       { jkind =
           mk_jkind Any ~mode_crossing:true ~nullability:Maybe_null
-            ~separability:Maybe_separable;
+            ~separability:Maybe_separable ~externality:Byte_external;
         name = "any mod everything"
       }
 
@@ -1335,7 +1339,7 @@ module Const = struct
     let any_non_null =
       { jkind =
           mk_jkind Any ~mode_crossing:false ~nullability:Non_null
-            ~separability:Separable;
+            ~separability:Separable ~externality:Internal;
         name = "any_non_null"
       }
 
@@ -1344,28 +1348,28 @@ module Const = struct
     let any_non_null_mod_everything =
       { jkind =
           mk_jkind Any ~mode_crossing:true ~nullability:Non_null
-            ~separability:Separable;
+            ~separability:Separable ~externality:Byte_external;
         name = "any_non_null mod everything"
       }
 
     let value_or_null =
       { jkind =
           mk_jkind (Base Value) ~mode_crossing:false ~nullability:Maybe_null
-            ~separability:Maybe_separable;
+            ~separability:Maybe_separable ~externality:Internal;
         name = "value_or_null"
       }
 
     let value_or_null_mod_everything =
       { jkind =
           mk_jkind (Base Value) ~mode_crossing:true ~nullability:Maybe_null
-            ~separability:Maybe_separable;
+            ~separability:Maybe_separable ~externality:Byte_external;
         name = "value_or_null mod everything"
       }
 
     let value =
       { jkind =
           mk_jkind (Base Value) ~mode_crossing:false ~nullability:Non_null
-            ~separability:Separable;
+            ~separability:Separable ~externality:Internal;
         name = "value"
       }
 
@@ -1379,7 +1383,8 @@ module Const = struct
                 ~uniqueness:Uniqueness.Const_op.max
                 ~contention:Contention.Const_op.min
                 ~statefulness:Statefulness.Const.min
-                ~visibility:Visibility.Const_op.min ~externality:Externality.max
+                ~visibility:Visibility.Const_op.min
+                ~externality:Mod_bounds.Externality.max
                 ~nullability:Nullability.Non_null
                 ~separability:Separability.Non_float;
             with_bounds = No_with_bounds
@@ -1397,7 +1402,8 @@ module Const = struct
                 ~uniqueness:Uniqueness.Const_op.max
                 ~contention:Contention.Const_op.min
                 ~statefulness:Statefulness.Const.min
-                ~visibility:Visibility.Const_op.max ~externality:Externality.max
+                ~visibility:Visibility.Const_op.max
+                ~externality:Mod_bounds.Externality.max
                 ~nullability:Nullability.Non_null
                 ~separability:Separability.Non_float;
             with_bounds = No_with_bounds
@@ -1415,7 +1421,8 @@ module Const = struct
                 ~contention:Contention.Const_op.max
                 ~uniqueness:Uniqueness.Const_op.max
                 ~statefulness:Statefulness.Const.min
-                ~visibility:Visibility.Const_op.max ~externality:Externality.max
+                ~visibility:Visibility.Const_op.max
+                ~externality:Mod_bounds.Externality.max
                 ~nullability:Nullability.Non_null
                 ~separability:Separability.Non_float;
             with_bounds = No_with_bounds
@@ -1428,14 +1435,14 @@ module Const = struct
     let void =
       { jkind =
           mk_jkind (Base Void) ~mode_crossing:false ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:Internal;
         name = "void"
       }
 
     let immediate =
       { jkind =
           mk_jkind (Base Value) ~mode_crossing:true ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:Byte_external;
         name = "immediate"
       }
 
@@ -1444,7 +1451,7 @@ module Const = struct
     let immediate_or_null =
       { jkind =
           mk_jkind (Base Value) ~mode_crossing:true ~nullability:Maybe_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:Byte_external;
         name = "immediate_or_null"
       }
 
@@ -1482,7 +1489,7 @@ module Const = struct
       { jkind =
           { immediate.jkind with
             mod_bounds =
-              Mod_bounds.set_externality Externality.External64
+              Mod_bounds.set_externality Mod_bounds.Externality.External64
                 immediate.jkind.mod_bounds
           };
         name = "immediate64"
@@ -1493,7 +1500,7 @@ module Const = struct
     let float64 =
       { jkind =
           mk_jkind (Base Float64) ~mode_crossing:false ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:Internal;
         (* [separability] is intentionally [Non_float]:
            only boxed floats are relevant for separability. *)
         name = "float64"
@@ -1502,9 +1509,11 @@ module Const = struct
     (* CR layouts v3: change to [Maybe_null] when
        [or_null array]s are implemented. *)
     let kind_of_unboxed_float =
-      { jkind =
-          mk_jkind (Base Float64) ~mode_crossing:true ~nullability:Non_null
-            ~separability:Non_float;
+      let jkind =
+        mk_jkind (Base Float64) ~mode_crossing:true ~nullability:Non_null
+          ~separability:Non_float ~externality:External
+      in
+      { jkind;
         (* [separability] is intentionally [Non_float]:
            only boxed floats are relevant for separability. *)
         name = "float64 mod everything"
@@ -1515,7 +1524,7 @@ module Const = struct
     let float32 =
       { jkind =
           mk_jkind (Base Float32) ~mode_crossing:false ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:Internal;
         (* [separability] is intentionally [Non_float]:
            only boxed floats are relevant for separability. *)
         name = "float32"
@@ -1526,7 +1535,7 @@ module Const = struct
     let kind_of_unboxed_float32 =
       { jkind =
           mk_jkind (Base Float32) ~mode_crossing:true ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:External;
         (* [separability] is intentionally [Non_float]:
            only boxed floats are relevant for separability. *)
         name = "float32 mod everything"
@@ -1537,7 +1546,7 @@ module Const = struct
     let word =
       { jkind =
           mk_jkind (Base Word) ~mode_crossing:false ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:Internal;
         name = "word"
       }
 
@@ -1546,7 +1555,7 @@ module Const = struct
     let kind_of_unboxed_nativeint =
       { jkind =
           mk_jkind (Base Word) ~mode_crossing:true ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:External;
         name = "word mod everything"
       }
 
@@ -1555,7 +1564,7 @@ module Const = struct
     let bits32 =
       { jkind =
           mk_jkind (Base Bits32) ~mode_crossing:false ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:Internal;
         name = "bits32"
       }
 
@@ -1564,7 +1573,7 @@ module Const = struct
     let kind_of_unboxed_int32 =
       { jkind =
           mk_jkind (Base Bits32) ~mode_crossing:true ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:External;
         name = "bits32 mod everything"
       }
 
@@ -1573,7 +1582,7 @@ module Const = struct
     let bits64 =
       { jkind =
           mk_jkind (Base Bits64) ~mode_crossing:false ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:Internal;
         name = "bits64"
       }
 
@@ -1582,7 +1591,7 @@ module Const = struct
     let kind_of_unboxed_int64 =
       { jkind =
           mk_jkind (Base Bits64) ~mode_crossing:true ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:External;
         name = "bits64 mod everything"
       }
 
@@ -1591,7 +1600,7 @@ module Const = struct
     let vec128 =
       { jkind =
           mk_jkind (Base Vec128) ~mode_crossing:false ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:Internal;
         name = "vec128"
       }
 
@@ -1600,7 +1609,7 @@ module Const = struct
     let vec256 =
       { jkind =
           mk_jkind (Base Vec256) ~mode_crossing:false ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:Internal;
         name = "vec256"
       }
 
@@ -1609,7 +1618,7 @@ module Const = struct
     let vec512 =
       { jkind =
           mk_jkind (Base Vec512) ~mode_crossing:false ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:Internal;
         name = "vec512"
       }
 
@@ -1618,7 +1627,7 @@ module Const = struct
     let kind_of_unboxed_128bit_vectors =
       { jkind =
           mk_jkind (Base Vec128) ~mode_crossing:true ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:External;
         name = "vec128 mod everything"
       }
 
@@ -1627,7 +1636,7 @@ module Const = struct
     let kind_of_unboxed_256bit_vectors =
       { jkind =
           mk_jkind (Base Vec256) ~mode_crossing:true ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:External;
         name = "vec256 mod everything"
       }
 
@@ -1636,7 +1645,7 @@ module Const = struct
     let kind_of_unboxed_512bit_vectors =
       { jkind =
           mk_jkind (Base Vec512) ~mode_crossing:true ~nullability:Non_null
-            ~separability:Non_float;
+            ~separability:Non_float ~externality:External;
         name = "vec512 mod everything"
       }
 
@@ -1710,6 +1719,14 @@ module Const = struct
       | Not_le -> `Invalid
 
     let get_modal_bounds ~(base : Mod_bounds.t) (actual : Mod_bounds.t) =
+      (* We don't ever want to show byte_external to the user, so we just promote
+         our base/actual to be at least external for pretty printing. *)
+      let base =
+        Mod_bounds.join base (Mod_bounds.set_externality External base)
+      in
+      let actual =
+        Mod_bounds.join actual (Mod_bounds.set_externality External actual)
+      in
       Axis.all
       |> List.map (fun (Axis.Pack axis) ->
              let base = Mod_bounds.get ~axis base in
@@ -2416,7 +2433,7 @@ let for_non_float ~(why : History.value_creation_reason) =
       ~linearity:Linearity.Const.max ~portability:Portability.Const.max
       ~yielding:Yielding.Const.max ~uniqueness:Uniqueness.Const_op.max
       ~contention:Contention.Const_op.max ~statefulness:Statefulness.Const.max
-      ~visibility:Visibility.Const_op.max ~externality:Externality.max
+      ~visibility:Visibility.Const_op.max ~externality:Externality.Const.max
       ~nullability:Nullability.Non_null ~separability:Separability.Non_float
   in
   fresh_jkind
@@ -2433,7 +2450,7 @@ let for_or_null_argument ident =
       ~linearity:Linearity.Const.max ~portability:Portability.Const.max
       ~yielding:Yielding.Const.max ~uniqueness:Uniqueness.Const_op.max
       ~contention:Contention.Const_op.max ~statefulness:Statefulness.Const.max
-      ~visibility:Visibility.Const_op.max ~externality:Externality.max
+      ~visibility:Visibility.Const_op.max ~externality:Externality.Const.max
       ~nullability:Nullability.Non_null
       ~separability:Separability.Maybe_separable
   in
@@ -2515,8 +2532,9 @@ let for_open_boxed_row =
       ~linearity:Linearity.Const.max ~portability:Portability.Const.max
       ~yielding:Yielding.Const.max ~uniqueness:Uniqueness.Const_op.max
       ~contention:Contention.Const_op.max ~statefulness:Statefulness.Const.max
-      ~visibility:Visibility.Const_op.max ~externality:Externality.max
-      ~nullability:Nullability.Non_null ~separability:Separability.Non_float
+      ~visibility:Visibility.Const_op.max
+      ~externality:Mod_bounds.Externality.max ~nullability:Nullability.Non_null
+      ~separability:Separability.Non_float
   in
   fresh_jkind
     { layout = Sort (Base Value); mod_bounds; with_bounds = No_with_bounds }
@@ -2552,7 +2570,13 @@ let for_object =
   (* The crossing of objects are based on the fact that they are
      produced/defined/allocated at legacy, which applies to only the
      comonadic axes. *)
-  let ({ linearity; areality = locality; portability; yielding; statefulness }
+  let ({ linearity;
+         areality = locality;
+         portability;
+         yielding;
+         statefulness;
+         externality
+       }
         : Mode.Alloc.Comonadic.Const.t) =
     Alloc.Comonadic.Const.legacy
   in
@@ -2563,9 +2587,8 @@ let for_object =
     { layout = Sort (Base Value);
       mod_bounds =
         Mod_bounds.create ~linearity ~locality ~uniqueness ~portability
-          ~contention ~yielding ~statefulness ~visibility
-          ~externality:Externality.max ~nullability:Non_null
-          ~separability:Separability.Non_float;
+          ~contention ~yielding ~statefulness ~visibility ~externality
+          ~nullability:Non_null ~separability:Separability.Non_float;
       with_bounds = No_with_bounds
     }
     ~annotation:None ~why:(Value_creation Object)
@@ -2576,8 +2599,9 @@ let for_float ident =
       ~linearity:Linearity.Const.min ~portability:Portability.Const.min
       ~yielding:Yielding.Const.min ~uniqueness:Uniqueness.Const_op.max
       ~contention:Contention.Const_op.min ~statefulness:Statefulness.Const.min
-      ~visibility:Visibility.Const_op.min ~externality:Externality.max
-      ~nullability:Nullability.Non_null ~separability:Separability.Separable
+      ~visibility:Visibility.Const_op.min
+      ~externality:Mod_bounds.Externality.max ~nullability:Nullability.Non_null
+      ~separability:Separability.Separable
   in
   fresh_jkind
     { layout = Sort (Base Value); mod_bounds; with_bounds = No_with_bounds }
@@ -2648,7 +2672,8 @@ let get_modal_bounds (type l r) ~jkind_of_type (jk : (l * r) jkind) =
           linearity = linearity mod_bounds;
           portability = portability mod_bounds;
           yielding = yielding mod_bounds;
-          statefulness = statefulness mod_bounds
+          statefulness = statefulness mod_bounds;
+          externality = externality mod_bounds
         };
       monadic =
         { uniqueness = uniqueness mod_bounds;
@@ -2667,7 +2692,7 @@ let to_unsafe_mode_crossing jkind =
   }
 
 let all_except_externality =
-  Axis_set.singleton (Nonmodal Externality) |> Axis_set.complement
+  Axis_set.singleton (Modal (Comonadic Externality)) |> Axis_set.complement
 
 let get_externality_upper_bound ~jkind_of_type jk =
   let ( ({ layout = _; mod_bounds; with_bounds = No_with_bounds } :
@@ -2676,7 +2701,7 @@ let get_externality_upper_bound ~jkind_of_type jk =
     Layout_and_axes.normalize ~mode:Ignore_best
       ~skip_axes:all_except_externality ~jkind_of_type jk.jkind
   in
-  Mod_bounds.get mod_bounds ~axis:(Nonmodal Externality)
+  Mod_bounds.get mod_bounds ~axis:(Modal (Comonadic Externality))
 
 let set_externality_upper_bound jk externality_upper_bound =
   { jk with

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -619,12 +619,12 @@ val to_unsafe_mode_crossing : Types.jkind_l -> Types.unsafe_mode_crossing
 val get_externality_upper_bound :
   jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
   'd Types.jkind ->
-  Jkind_axis.Externality.t
+  Mode.Externality.Const.t
 
 (** Computes a jkind that is the same as the input but with an updated maximum
     mode for the externality axis *)
 val set_externality_upper_bound :
-  Types.jkind_r -> Jkind_axis.Externality.t -> Types.jkind_r
+  Types.jkind_r -> Mode.Externality.Const.t -> Types.jkind_r
 
 (** Gets the nullability from a jkind. *)
 val get_nullability :

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -616,8 +616,6 @@ val get_mode_crossing :
 
 val to_unsafe_mode_crossing : Types.jkind_l -> Types.unsafe_mode_crossing
 
-(* CR jcutler: these two functions should probably go away, since this
-   is now covered by the existing functiosn to get and set the axis.*)
 val get_externality_upper_bound :
   jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
   'd Types.jkind ->

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -616,6 +616,8 @@ val get_mode_crossing :
 
 val to_unsafe_mode_crossing : Types.jkind_l -> Types.unsafe_mode_crossing
 
+(* CR jcutler: these two functions should probably go away, since this
+   is now covered by the existing functiosn to get and set the axis.*)
 val get_externality_upper_bound :
   jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
   'd Types.jkind ->

--- a/typing/jkind_axis.mli
+++ b/typing/jkind_axis.mli
@@ -21,16 +21,6 @@ module type Axis_ops = sig
   val equal : t -> t -> bool
 end
 
-(** The jkind axis of Externality *)
-module Externality : sig
-  type t =
-    | External
-    | External64
-    | Internal
-
-  include Axis_ops with type t := t
-end
-
 (** The jkind axis of nullability *)
 module Nullability : sig
   type t =
@@ -52,7 +42,6 @@ end
 module Axis : sig
   module Nonmodal : sig
     type 'a t =
-      | Externality : Externality.t t
       | Nullability : Nullability.t t
       | Separability : Separability.t t
   end

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -45,7 +45,7 @@ module type CoHeyting = sig
   val subtract : t -> t -> t
 end
 
-(* Even though our lattices are all bi-heyting algebras, that knowledge is
+(* Even thoudgh our lattices are all bi-heyting algebras, that knowledge is
    internal to this module. Externally they are seen as normal lattices. *)
 module Lattices = struct
   module Total = struct

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -45,7 +45,7 @@ module type CoHeyting = sig
   val subtract : t -> t -> t
 end
 
-(* Even thoudgh our lattices are all bi-heyting algebras, that knowledge is
+(* Even though our lattices are all bi-heyting algebras, that knowledge is
    internal to this module. Externally they are seen as normal lattices. *)
 module Lattices = struct
   module Total = struct

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -491,6 +491,94 @@ module Lattices = struct
     end)
   end
 
+  module Externality = struct
+    type t =
+      (* What is byte_external? It includes types like int/bool, but excludes
+         types like #(int * int), which are external on native code systems, but
+         not when compiled with bytecode. This is necessary so we don't skip
+         [caml_modify]s for such types. *)
+      | Byte_external
+      | External
+      | External64
+      | Internal
+
+    module Const = struct
+      type nonrec t = t
+    end
+
+    include Total.Heyting (struct
+      open Const
+
+      type nonrec t = t
+
+      let min = Byte_external
+
+      let max = Internal
+
+      let legacy = Internal
+
+      let le a b =
+        match a, b with
+        | Byte_external, _ -> true
+        | External, (External | External64 | Internal) -> true
+        | External, Byte_external -> false
+        | External64, (External64 | Internal) -> true
+        | External64, (Byte_external | External) -> false
+        | Internal, Internal -> true
+        | Internal, (Byte_external | External | External64) -> false
+
+      let equal a b =
+        match a, b with
+        | Byte_external, Byte_external -> true
+        | External, External -> true
+        | External64, External64 -> true
+        | Internal, Internal -> true
+        | Byte_external, (External | External64 | Internal)
+        | External, (Byte_external | External64 | Internal)
+        | External64, (Byte_external | External | Internal)
+        | Internal, (Byte_external | External | External64) ->
+          false
+
+      let join a b =
+        match a, b with
+        | Byte_external, _ -> b
+        | External, Byte_external -> External
+        | External, _ -> b
+        | External64, (Byte_external | External) -> External64
+        | External64, _ -> b
+        | Internal, (Byte_external | External | External64 | Internal) ->
+          Internal
+
+      let meet a b =
+        match a, b with
+        | Byte_external, (Byte_external | External | External64 | Internal) ->
+          Byte_external
+        | External, Byte_external -> Byte_external
+        | External, (External | External64 | Internal) -> External
+        | External64, (External | Byte_external | External64) -> b
+        | External64, Internal -> External64
+        | Internal, (Byte_external | External | External64) -> b
+        | Internal, Internal -> Internal
+
+      let print ppf = function
+        (* We never want to show the programmer byte_external. Jane Street
+           libraries relying on externality are written with the intent of being
+           used in native-compiled code, so clients should never come across
+           byte_external "in the wild". Seeing it in error messages would just
+           confuse them.
+
+           Since you *can* write byte_external in programs, this means that you
+           can write a program that typechecks, print it out, and then the
+           printed code will fail to typecheck. But this is just something we're
+           going to live with for now.
+        *)
+        | Byte_external -> Format.fprintf ppf "external_"
+        | External -> Format.fprintf ppf "external_"
+        | External64 -> Format.fprintf ppf "external64"
+        | Internal -> Format.fprintf ppf "internal"
+    end)
+  end
+
   type monadic =
     { uniqueness : Uniqueness.t;
       contention : Contention.t;
@@ -580,7 +668,8 @@ module Lattices = struct
       linearity : Linearity.t;
       portability : Portability.t;
       yielding : Yielding.t;
-      statefulness : Statefulness.t
+      statefulness : Statefulness.t;
+      externality : Externality.t
     }
 
   module Comonadic_with (Areality : Areality) = struct
@@ -592,7 +681,8 @@ module Lattices = struct
       let portability = Portability.min in
       let yielding = Yielding.min in
       let statefulness = Statefulness.min in
-      { areality; linearity; portability; yielding; statefulness }
+      let externality = Externality.min in
+      { areality; linearity; portability; yielding; statefulness; externality }
 
     let max =
       let areality = Areality.max in
@@ -600,7 +690,8 @@ module Lattices = struct
       let portability = Portability.max in
       let yielding = Yielding.max in
       let statefulness = Statefulness.max in
-      { areality; linearity; portability; yielding; statefulness }
+      let externality = Externality.max in
+      { areality; linearity; portability; yielding; statefulness; externality }
 
     let legacy =
       let areality = Areality.legacy in
@@ -608,14 +699,16 @@ module Lattices = struct
       let portability = Portability.legacy in
       let yielding = Yielding.legacy in
       let statefulness = Statefulness.legacy in
-      { areality; linearity; portability; yielding; statefulness }
+      let externality = Externality.legacy in
+      { areality; linearity; portability; yielding; statefulness; externality }
 
     let le m1 m2 =
       let { areality = areality1;
             linearity = linearity1;
             portability = portability1;
             yielding = yielding1;
-            statefulness = statefulness1
+            statefulness = statefulness1;
+            externality = externality1
           } =
         m1
       in
@@ -623,7 +716,8 @@ module Lattices = struct
             linearity = linearity2;
             portability = portability2;
             yielding = yielding2;
-            statefulness = statefulness2
+            statefulness = statefulness2;
+            externality = externality2
           } =
         m2
       in
@@ -632,13 +726,15 @@ module Lattices = struct
       && Portability.le portability1 portability2
       && Yielding.le yielding1 yielding2
       && Statefulness.le statefulness1 statefulness2
+      && Externality.le externality1 externality2
 
     let equal m1 m2 =
       let { areality = areality1;
             linearity = linearity1;
             portability = portability1;
             yielding = yielding1;
-            statefulness = statefulness1
+            statefulness = statefulness1;
+            externality = externality1
           } =
         m1
       in
@@ -646,7 +742,8 @@ module Lattices = struct
             linearity = linearity2;
             portability = portability2;
             yielding = yielding2;
-            statefulness = statefulness2
+            statefulness = statefulness2;
+            externality = externality2
           } =
         m2
       in
@@ -655,6 +752,7 @@ module Lattices = struct
       && Portability.equal portability1 portability2
       && Yielding.equal yielding1 yielding2
       && Statefulness.equal statefulness1 statefulness2
+      && Externality.equal externality1 externality2
 
     let join m1 m2 =
       let areality = Areality.join m1.areality m2.areality in
@@ -662,7 +760,8 @@ module Lattices = struct
       let portability = Portability.join m1.portability m2.portability in
       let yielding = Yielding.join m1.yielding m2.yielding in
       let statefulness = Statefulness.join m1.statefulness m2.statefulness in
-      { areality; linearity; portability; yielding; statefulness }
+      let externality = Externality.join m1.externality m2.externality in
+      { areality; linearity; portability; yielding; statefulness; externality }
 
     let meet m1 m2 =
       let areality = Areality.meet m1.areality m2.areality in
@@ -670,7 +769,8 @@ module Lattices = struct
       let portability = Portability.meet m1.portability m2.portability in
       let yielding = Yielding.meet m1.yielding m2.yielding in
       let statefulness = Statefulness.meet m1.statefulness m2.statefulness in
-      { areality; linearity; portability; yielding; statefulness }
+      let externality = Externality.meet m1.externality m2.externality in
+      { areality; linearity; portability; yielding; statefulness; externality }
 
     let imply m1 m2 =
       let areality = Areality.imply m1.areality m2.areality in
@@ -678,12 +778,14 @@ module Lattices = struct
       let portability = Portability.imply m1.portability m2.portability in
       let yielding = Yielding.imply m1.yielding m2.yielding in
       let statefulness = Statefulness.imply m1.statefulness m2.statefulness in
-      { areality; linearity; portability; yielding; statefulness }
+      let externality = Externality.imply m1.externality m2.externality in
+      { areality; linearity; portability; yielding; statefulness; externality }
 
     let print ppf m =
-      Format.fprintf ppf "%a,%a,%a,%a,%a" Areality.print m.areality
+      Format.fprintf ppf "%a,%a,%a,%a,%a,%a" Areality.print m.areality
         Linearity.print m.linearity Portability.print m.portability
         Yielding.print m.yielding Statefulness.print m.statefulness
+        Externality.print m.externality
   end
   [@@inline]
 
@@ -741,6 +843,7 @@ module Lattices = struct
     | Portability : Portability.t obj
     | Yielding : Yielding.t obj
     | Statefulness : Statefulness.t obj
+    | Externality : Externality.t obj
     | Contention_op : Contention_op.t obj
     | Visibility_op : Visibility_op.t obj
     | Monadic_op : Monadic_op.t obj
@@ -756,6 +859,7 @@ module Lattices = struct
     | Portability -> Format.fprintf ppf "Portability"
     | Yielding -> Format.fprintf ppf "Yielding"
     | Statefulness -> Format.fprintf ppf "Statefulness"
+    | Externality -> Format.fprintf ppf "Externality"
     | Contention_op -> Format.fprintf ppf "Contention_op"
     | Visibility_op -> Format.fprintf ppf "Visibility_op"
     | Monadic_op -> Format.fprintf ppf "Monadic_op"
@@ -771,6 +875,7 @@ module Lattices = struct
     | Visibility_op -> Visibility_op.min
     | Yielding -> Yielding.min
     | Statefulness -> Statefulness.min
+    | Externality -> Externality.min
     | Linearity -> Linearity.min
     | Portability -> Portability.min
     | Monadic_op -> Monadic_op.min
@@ -787,6 +892,7 @@ module Lattices = struct
     | Portability -> Portability.max
     | Yielding -> Yielding.max
     | Statefulness -> Statefulness.max
+    | Externality -> Externality.max
     | Monadic_op -> Monadic_op.max
     | Comonadic_with_locality -> Comonadic_with_locality.max
     | Comonadic_with_regionality -> Comonadic_with_regionality.max
@@ -803,6 +909,7 @@ module Lattices = struct
     | Portability -> Portability.le a b
     | Yielding -> Yielding.le a b
     | Statefulness -> Statefulness.le a b
+    | Externality -> Externality.le a b
     | Monadic_op -> Monadic_op.le a b
     | Comonadic_with_locality -> Comonadic_with_locality.le a b
     | Comonadic_with_regionality -> Comonadic_with_regionality.le a b
@@ -819,6 +926,7 @@ module Lattices = struct
     | Portability -> Portability.join a b
     | Yielding -> Yielding.join a b
     | Statefulness -> Statefulness.join a b
+    | Externality -> Externality.join a b
     | Monadic_op -> Monadic_op.join a b
     | Comonadic_with_locality -> Comonadic_with_locality.join a b
     | Comonadic_with_regionality -> Comonadic_with_regionality.join a b
@@ -835,6 +943,7 @@ module Lattices = struct
     | Portability -> Portability.meet a b
     | Yielding -> Yielding.meet a b
     | Statefulness -> Statefulness.meet a b
+    | Externality -> Externality.meet a b
     | Monadic_op -> Monadic_op.meet a b
     | Comonadic_with_locality -> Comonadic_with_locality.meet a b
     | Comonadic_with_regionality -> Comonadic_with_regionality.meet a b
@@ -851,6 +960,7 @@ module Lattices = struct
     | Portability -> Portability.imply a b
     | Yielding -> Yielding.imply a b
     | Statefulness -> Statefulness.imply a b
+    | Externality -> Externality.imply a b
     | Comonadic_with_locality -> Comonadic_with_locality.imply a b
     | Comonadic_with_regionality -> Comonadic_with_regionality.imply a b
     | Monadic_op -> Monadic_op.imply a b
@@ -866,6 +976,7 @@ module Lattices = struct
     | Portability -> Portability.print
     | Yielding -> Yielding.print
     | Statefulness -> Statefulness.print
+    | Externality -> Externality.print
     | Monadic_op -> Monadic_op.print
     | Comonadic_with_locality -> Comonadic_with_locality.print
     | Comonadic_with_regionality -> Comonadic_with_regionality.print
@@ -885,12 +996,14 @@ module Lattices = struct
       | Portability, Portability -> Some Refl
       | Yielding, Yielding -> Some Refl
       | Statefulness, Statefulness -> Some Refl
+      | Externality, Externality -> Some Refl
       | Monadic_op, Monadic_op -> Some Refl
       | Comonadic_with_locality, Comonadic_with_locality -> Some Refl
       | Comonadic_with_regionality, Comonadic_with_regionality -> Some Refl
       | ( ( Locality | Regionality | Uniqueness_op | Contention_op
           | Visibility_op | Linearity | Portability | Yielding | Statefulness
-          | Monadic_op | Comonadic_with_locality | Comonadic_with_regionality ),
+          | Externality | Monadic_op | Comonadic_with_locality
+          | Comonadic_with_regionality ),
           _ ) ->
         None
   end)
@@ -908,6 +1021,7 @@ module Lattices_mono = struct
       | Linearity : ('areality comonadic_with, Linearity.t) t
       | Statefulness : ('areality comonadic_with, Statefulness.t) t
       | Portability : ('areality comonadic_with, Portability.t) t
+      | Externality : ('areality comonadic_with, Externality.t) t
       | Uniqueness : (Monadic_op.t, Uniqueness_op.t) t
       | Visibility : (Monadic_op.t, Visibility_op.t) t
       | Contention : (Monadic_op.t, Contention_op.t) t
@@ -921,6 +1035,7 @@ module Lattices_mono = struct
       | Uniqueness -> 5
       | Visibility -> 6
       | Contention -> 7
+      | Externality -> 8
 
     let compare a b = to_int a - to_int b
 
@@ -934,6 +1049,7 @@ module Lattices_mono = struct
       | Yielding -> Format.fprintf ppf "yielding"
       | Statefulness -> Format.fprintf ppf "statefulness"
       | Visibility -> Format.fprintf ppf "visibility"
+      | Externality -> Format.fprintf ppf "externality"
 
     let eq : type p r0 r1. (p, r0) t -> (p, r1) t -> (r0, r1) Misc.eq option =
      fun ax0 ax1 ->
@@ -946,8 +1062,9 @@ module Lattices_mono = struct
       | Yielding, Yielding -> Some Refl
       | Statefulness, Statefulness -> Some Refl
       | Visibility, Visibility -> Some Refl
+      | Externality, Externality -> Some Refl
       | ( ( Areality | Linearity | Uniqueness | Portability | Contention
-          | Yielding | Statefulness | Visibility ),
+          | Yielding | Statefulness | Visibility | Externality ),
           _ ) ->
         None
 
@@ -962,6 +1079,7 @@ module Lattices_mono = struct
       | Uniqueness -> t.uniqueness
       | Contention -> t.contention
       | Visibility -> t.visibility
+      | Externality -> t.externality
 
     let set : type p r. (p, r) t -> r -> p -> p =
      fun ax r t ->
@@ -974,6 +1092,7 @@ module Lattices_mono = struct
       | Uniqueness -> { t with uniqueness = r }
       | Contention -> { t with contention = r }
       | Visibility -> { t with visibility = r }
+      | Externality -> { t with externality = r }
   end
 
   type ('a, 'b, 'd) morph =
@@ -1133,6 +1252,8 @@ module Lattices_mono = struct
     | Yielding, Comonadic_with_regionality -> Yielding
     | Statefulness, Comonadic_with_locality -> Statefulness
     | Statefulness, Comonadic_with_regionality -> Statefulness
+    | Externality, Comonadic_with_locality -> Externality
+    | Externality, Comonadic_with_regionality -> Externality
     | Uniqueness, Monadic_op -> Uniqueness_op
     | Contention, Monadic_op -> Contention_op
     | Visibility, Monadic_op -> Visibility_op
@@ -1144,7 +1265,7 @@ module Lattices_mono = struct
     | Regionality -> Comonadic_with_regionality
     | Uniqueness_op | Linearity | Monadic_op | Comonadic_with_regionality
     | Comonadic_with_locality | Contention_op | Visibility_op | Portability
-    | Yielding | Statefulness ->
+    | Yielding | Statefulness | Externality ->
       assert false
 
   let rec src : type a b l r. b obj -> (a, b, l * r) morph -> a obj =
@@ -1320,7 +1441,8 @@ module Lattices_mono = struct
     let portability = contended_to_portable m.contention in
     let yielding = Yielding.min in
     let statefulness = visibility_to_statefulness m.visibility in
-    { areality; linearity; portability; yielding; statefulness }
+    let externality = Externality.min in
+    { areality; linearity; portability; yielding; statefulness; externality }
 
   let comonadic_to_monadic :
       type a. a comonadic_with obj -> a comonadic_with -> Monadic_op.t =
@@ -1342,7 +1464,8 @@ module Lattices_mono = struct
     let portability = contended_to_portable m.contention in
     let yielding = Yielding.max in
     let statefulness = visibility_to_statefulness m.visibility in
-    { areality; linearity; portability; yielding; statefulness }
+    let externality = Externality.max in
+    { areality; linearity; portability; yielding; statefulness; externality }
 
   let rec apply : type a b l r. b obj -> (a, b, l * r) morph -> a -> b =
    fun dst f a ->
@@ -1418,7 +1541,8 @@ module Lattices_mono = struct
       | Linearity -> Some (Proj (src', Linearity))
       | Portability -> Some (Proj (src', Portability))
       | Yielding -> Some (Proj (src', Yielding))
-      | Statefulness -> Some (Proj (src', Statefulness)))
+      | Statefulness -> Some (Proj (src', Statefulness))
+      | Externality -> Some (Proj (src', Externality)))
     | Proj _, Monadic_to_comonadic_min -> None
     | Proj _, Monadic_to_comonadic_max -> None
     | Proj _, Comonadic_to_monadic _ -> None
@@ -1565,7 +1689,8 @@ type 'a comonadic_with = 'a C.comonadic_with =
     linearity : C.Linearity.t;
     portability : C.Portability.t;
     yielding : C.Yielding.t;
-    statefulness : C.Statefulness.t
+    statefulness : C.Statefulness.t;
+    externality : C.Externality.t
   }
 
 module Axis = C.Axis
@@ -1867,6 +1992,30 @@ module Statefulness = struct
   let zap_to_legacy = zap_to_ceil
 end
 
+module Externality = struct
+  module Const = C.Externality
+
+  module Obj = struct
+    type const = Const.t
+
+    let obj = C.Externality
+  end
+
+  include Comonadic_gen (Obj)
+
+  let byte_external = of_const Byte_external
+
+  let external_ = of_const External
+
+  let external64 = of_const External64
+
+  let internal = of_const Internal
+
+  let legacy = of_const Const.legacy
+
+  let zap_to_legacy = zap_to_ceil
+end
+
 module Visibility = struct
   module Const = C.Visibility
   module Const_op = C.Visibility_op
@@ -2020,7 +2169,12 @@ module Comonadic_with (Areality : Areality) = struct
     let compare = Axis.compare
 
     let all =
-      [P Areality; P Linearity; P Portability; P Yielding; P Statefulness]
+      [ P Areality;
+        P Linearity;
+        P Portability;
+        P Yielding;
+        P Statefulness;
+        P Externality ]
       |> List.sort (fun (P ax0) (P ax1) -> compare ax0 ax1)
   end
 
@@ -2050,6 +2204,7 @@ module Comonadic_with (Areality : Areality) = struct
       | Portability -> (module Portability.Const)
       | Yielding -> (module Yielding.Const)
       | Statefulness -> (module Statefulness.Const)
+      | Externality -> (module Externality.Const)
   end
 
   let proj ax m = Solver.apply (proj_obj ax) (Proj (Obj.obj, ax)) m
@@ -2071,7 +2226,8 @@ module Comonadic_with (Areality : Areality) = struct
     in
     let global = Areality.Const.(equal areality legacy) in
     let yielding = proj Yielding m |> Yielding.zap_to_legacy ~global in
-    { areality; linearity; portability; yielding; statefulness }
+    let externality = proj Externality m |> Externality.zap_to_legacy in
+    { areality; linearity; portability; yielding; statefulness; externality }
 
   let legacy = of_const Const.legacy
 
@@ -2081,14 +2237,16 @@ module Comonadic_with (Areality : Areality) = struct
               linearity = linearity1;
               portability = portability1;
               yielding = yielding1;
-              statefulness = statefulness1
+              statefulness = statefulness1;
+              externality = externality1
             };
           right =
             { areality = areality2;
               linearity = linearity2;
               portability = portability2;
               yielding = yielding2;
-              statefulness = statefulness2
+              statefulness = statefulness2;
+              externality = externality2
             }
         } =
       err
@@ -2102,7 +2260,15 @@ module Comonadic_with (Areality : Areality) = struct
           if Yielding.Const.le yielding1 yielding2
           then
             if Statefulness.Const.le statefulness1 statefulness2
-            then assert false
+            then
+              if Externality.Const.le externality1 externality2
+              then assert false
+              else
+                Error
+                  ( Externality,
+                    { left = err.left.externality;
+                      right = err.right.externality
+                    } )
             else
               Error
                 ( Statefulness,
@@ -2298,7 +2464,7 @@ module Value_with (Areality : Areality) = struct
     | Monadic ax -> Monadic.proj_obj ax
     | Comonadic ax -> Comonadic.proj_obj ax
 
-  type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h) modes =
+  type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) modes =
     { areality : 'a;
       linearity : 'b;
       uniqueness : 'c;
@@ -2306,7 +2472,8 @@ module Value_with (Areality : Areality) = struct
       contention : 'e;
       yielding : 'f;
       statefulness : 'g;
-      visibility : 'h
+      visibility : 'h;
+      externality : 'i
     }
 
   let split
@@ -2317,16 +2484,23 @@ module Value_with (Areality : Areality) = struct
         statefulness;
         uniqueness;
         contention;
-        visibility
+        visibility;
+        externality
       } =
     let monadic : Monadic.Const.t = { uniqueness; contention; visibility } in
     let comonadic : Comonadic.Const.t =
-      { areality; linearity; portability; yielding; statefulness }
+      { areality; linearity; portability; yielding; statefulness; externality }
     in
     { comonadic; monadic }
 
   let merge { comonadic; monadic } =
-    let ({ areality; linearity; portability; yielding; statefulness }
+    let ({ areality;
+           linearity;
+           portability;
+           yielding;
+           statefulness;
+           externality
+         }
           : Comonadic.Const.t) =
       comonadic
     in
@@ -2338,7 +2512,8 @@ module Value_with (Areality : Areality) = struct
       statefulness;
       uniqueness;
       contention;
-      visibility
+      visibility;
+      externality
     }
 
   let print ?verbose () ppf { monadic; comonadic } =
@@ -2366,7 +2541,8 @@ module Value_with (Areality : Areality) = struct
         Contention.Const.t,
         Yielding.Const.t,
         Statefulness.Const.t,
-        Visibility.Const.t )
+        Visibility.Const.t,
+        Externality.Const.t )
       modes
 
     let min = merge { comonadic = Comonadic.min; monadic = Monadic.min }
@@ -2422,7 +2598,8 @@ module Value_with (Areality : Areality) = struct
           Contention.Const.t option,
           Yielding.Const.t option,
           Statefulness.Const.t option,
-          Visibility.Const.t option )
+          Visibility.Const.t option,
+          Externality.Const.t option )
         modes
 
       let none =
@@ -2433,7 +2610,8 @@ module Value_with (Areality : Areality) = struct
           contention = None;
           yielding = None;
           statefulness = None;
-          visibility = None
+          visibility = None;
+          externality = None
         }
 
       let value opt ~default =
@@ -2455,6 +2633,9 @@ module Value_with (Areality : Areality) = struct
         let visibility =
           Option.value opt.visibility ~default:default.visibility
         in
+        let externality =
+          Option.value opt.externality ~default:default.externality
+        in
         { areality;
           uniqueness;
           linearity;
@@ -2462,7 +2643,8 @@ module Value_with (Areality : Areality) = struct
           contention;
           yielding;
           statefulness;
-          visibility
+          visibility;
+          externality
         }
 
       let print ppf
@@ -2512,6 +2694,9 @@ module Value_with (Areality : Areality) = struct
         diff Statefulness.Const.le m0.statefulness m1.statefulness
       in
       let visibility = diff Visibility.Const.le m0.visibility m1.visibility in
+      let externality =
+        diff Externality.Const.le m0.externality m1.externality
+      in
       { areality;
         linearity;
         uniqueness;
@@ -2519,7 +2704,8 @@ module Value_with (Areality : Areality) = struct
         contention;
         yielding;
         statefulness;
-        visibility
+        visibility;
+        externality
       }
 
     (** See [Alloc.close_over] for explanation. *)
@@ -2770,7 +2956,8 @@ module Const = struct
          contention;
          yielding;
          statefulness;
-         visibility
+         visibility;
+         externality
        } :
         Alloc.Const.t) : Value.Const.t =
     let areality = C.locality_as_regionality areality in
@@ -2781,7 +2968,8 @@ module Const = struct
       contention;
       yielding;
       statefulness;
-      visibility
+      visibility;
+      externality
     }
 
   module Axis = struct
@@ -2791,6 +2979,7 @@ module Const = struct
       | P (Comonadic Portability) -> P (Comonadic Portability)
       | P (Comonadic Yielding) -> P (Comonadic Yielding)
       | P (Comonadic Statefulness) -> P (Comonadic Statefulness)
+      | P (Comonadic Externality) -> P (Comonadic Externality)
       | P (Monadic Uniqueness) -> P (Monadic Uniqueness)
       | P (Monadic Contention) -> P (Monadic Contention)
       | P (Monadic Visibility) -> P (Monadic Visibility)

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -371,12 +371,38 @@ module type S = sig
     val read_write : lr
   end
 
+  module Externality : sig
+    module Const : sig
+      type t =
+        | Byte_external
+        | External
+        | External64
+        | Internal
+
+      include Lattice with type t := t
+    end
+
+    include
+      Common_axis
+        with module Const := Const
+         and type 'd t = (Const.t, 'd pos) mode
+
+    val byte_external : lr
+
+    val external_ : lr
+
+    val external64 : lr
+
+    val internal : lr
+  end
+
   type 'a comonadic_with =
     { areality : 'a;
       linearity : Linearity.Const.t;
       portability : Portability.Const.t;
       yielding : Yielding.Const.t;
-      statefulness : Statefulness.Const.t
+      statefulness : Statefulness.Const.t;
+      externality : Externality.Const.t
     }
 
   type monadic =
@@ -396,6 +422,7 @@ module type S = sig
       | Linearity : ('areality comonadic_with, Linearity.Const.t) t
       | Statefulness : ('areality comonadic_with, Statefulness.Const.t) t
       | Portability : ('areality comonadic_with, Portability.Const.t) t
+      | Externality : ('areality comonadic_with, Externality.Const.t) t
       | Uniqueness : (monadic, Uniqueness.Const.t) t
       | Visibility : (monadic, Visibility.Const.t) t
       | Contention : (monadic, Contention.Const.t) t
@@ -432,7 +459,7 @@ module type S = sig
       include Axis with type 'a t := 'a t
     end
 
-    type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h) modes =
+    type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) modes =
       { areality : 'a;
         linearity : 'b;
         uniqueness : 'c;
@@ -440,7 +467,8 @@ module type S = sig
         contention : 'e;
         yielding : 'f;
         statefulness : 'g;
-        visibility : 'h
+        visibility : 'h;
+        externality : 'i
       }
 
     module Const : sig
@@ -454,7 +482,8 @@ module type S = sig
               Contention.Const.t,
               Yielding.Const.t,
               Statefulness.Const.t,
-              Visibility.Const.t )
+              Visibility.Const.t,
+              Externality.Const.t )
             modes
 
       (** Gets the normal lattice for comonadic axes and the "op"ped lattice for
@@ -472,7 +501,8 @@ module type S = sig
             Contention.Const.t option,
             Yielding.Const.t option,
             Statefulness.Const.t option,
-            Visibility.Const.t option )
+            Visibility.Const.t option,
+            Externality.Const.t option )
           modes
 
         val none : t

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -40,6 +40,7 @@ and ident_array = ident_create "array"
 and ident_iarray = ident_create "iarray"
 and ident_list = ident_create "list"
 and ident_option = ident_create "option"
+and ident_mallocd = ident_create "mallocd"
 and ident_nativeint = ident_create "nativeint"
 and ident_int8 = ident_create "int8"
 and ident_int16 = ident_create "int16"
@@ -84,6 +85,7 @@ and path_array = Pident ident_array
 and path_iarray = Pident ident_iarray
 and path_list = Pident ident_list
 and path_option = Pident ident_option
+and path_mallocd = Pident ident_mallocd
 and path_nativeint = Pident ident_nativeint
 and path_int8 = Pident ident_int8
 and path_int16 = Pident ident_int16
@@ -155,6 +157,7 @@ and type_array t = newgenty (Tconstr(path_array, [t], ref Mnil))
 and type_iarray t = newgenty (Tconstr(path_iarray, [t], ref Mnil))
 and type_list t = newgenty (Tconstr(path_list, [t], ref Mnil))
 and type_option t = newgenty (Tconstr(path_option, [t], ref Mnil))
+and type_mallocd t = newgenty (Tconstr(path_mallocd, [t], ref Mnil))
 and type_nativeint = newgenty (Tconstr(path_nativeint, [], ref Mnil))
 and type_int32 = newgenty (Tconstr(path_int32, [], ref Mnil))
 and type_int64 = newgenty (Tconstr(path_int64, [], ref Mnil))
@@ -532,6 +535,12 @@ let build_initial_env add_type add_extension empty_env =
          Jkind.add_with_bounds
            ~modality:Mode.Modality.Value.Const.id
            ~type_expr:param)
+  |> add_type1 ident_mallocd
+       ~variance:Variance.covariant
+       ~separability:Separability.Sep
+       ~param_jkind:(Jkind.Builtin.value_or_null ~why:(Type_argument {parent_path = path_mallocd; position = 1; arity = 1}))
+       ~jkind:(fun _param ->
+         Jkind.of_builtin Jkind.Const.Builtin.bits64 ~why:(Primitive ident_mallocd) )
   |> add_type_with_jkind ident_lexing_position
        ~kind:(
          let lbl (field, field_type) =

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -30,6 +30,7 @@ val type_array: type_expr -> type_expr
 val type_iarray: type_expr -> type_expr
 val type_list: type_expr -> type_expr
 val type_option: type_expr -> type_expr
+val type_mallocd: type_expr -> type_expr
 val type_nativeint: type_expr
 val type_int8: type_expr
 val type_int16: type_expr
@@ -98,6 +99,7 @@ val path_array: Path.t
 val path_iarray: Path.t
 val path_list: Path.t
 val path_option: Path.t
+val path_mallocd: Path.t
 val path_nativeint: Path.t
 val path_int8: Path.t
 val path_int16: Path.t

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -679,6 +679,9 @@ and expression i ppf x =
     expression i ppf e2
   | Texp_hole _ ->
     line i ppf "Texp_hole"
+  | Texp_alloc (e,_) ->
+      line i ppf "Texp_alloc";
+      expression i ppf e;
 
 and value_description i ppf x =
   line i ppf "value_description %a %a\n" fmt_ident x.val_id fmt_location

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -456,6 +456,8 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
     sub.expr sub exp1;
     sub.expr sub exp2
   | Texp_hole _ -> ()
+  | Texp_alloc (exp, _) ->
+      sub.expr sub exp
 
 
 let package_type sub {pack_fields; pack_txt; _} =

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -640,6 +640,8 @@ let expr sub x =
     | Texp_overwrite (exp1, exp2) ->
         Texp_overwrite (sub.expr sub exp1, sub.expr sub exp2)
     | Texp_hole use -> Texp_hole use
+    | Texp_alloc (exp,alloc) ->
+        Texp_alloc (sub.expr sub exp, alloc)
   in
   let exp_attributes = sub.attributes sub x.exp_attributes in
   {x with exp_loc; exp_extra; exp_desc; exp_env; exp_attributes}

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -694,30 +694,52 @@ let global_pat_mode {mode; _}=
 
 let allocations : Alloc.r list ref = Local_store.s_ref []
 
+
 let reset_allocations () = allocations := []
 
-let register_allocation_mode alloc_mode =
+let lower_bound_externality ~loc ~env lower_bound alloc_mode =
+  let externality = Alloc.proj_comonadic Externality alloc_mode in
+  let res = Externality.submode lower_bound externality in
+  (match res with
+  | Ok () -> ()
+  | Error failure_reason ->
+      let error =
+        Submode_failed(Value.Error (Comonadic Externality,failure_reason),
+          Other, None,
+          None, None, None)
+      in
+      raise (Error(loc, env, error)))
+
+let register_bytecode_allocation_mode ~loc ~env alloc_mode =
+  lower_bound_externality ~loc ~env Externality.external_ alloc_mode
+
+let register_allocation_mode ~loc ~env alloc_mode =
+  lower_bound_externality ~loc ~env Externality.internal alloc_mode;
   let alloc_mode = Alloc.disallow_left alloc_mode in
   allocations := alloc_mode :: !allocations
 
-let register_allocation_value_mode mode =
+let register_allocation_value_mode ~loc ~env mode =
   let alloc_mode = value_to_alloc_r2g mode in
-  register_allocation_mode alloc_mode;
+  register_allocation_mode ~loc ~env alloc_mode;
   let mode = alloc_as_value alloc_mode in
   alloc_mode, mode
 
 (** Register as allocation the expression constrained by the given
     [expected_mode]. Returns the mode of the allocation, and the expected mode
     of potential subcomponents. *)
-let register_allocation (expected_mode : expected_mode) =
+let register_allocation ~loc ~env (expected_mode : expected_mode) =
   let alloc_mode, mode =
-    register_allocation_value_mode (as_single_mode expected_mode)
+    register_allocation_value_mode ~loc ~env (as_single_mode expected_mode)
   in
   let alloc_mode : alloc_mode =
     { mode = alloc_mode;
       locality_context = expected_mode.locality_context }
   in
   alloc_mode, mode_default mode
+
+let register_bytecode_allocation ~loc ~env (expected_mode : expected_mode) =
+  let alloc_mode = value_to_alloc_r2g (as_single_mode expected_mode) in
+  register_bytecode_allocation_mode ~loc ~env alloc_mode
 
 let optimise_allocations () =
   (* CR zqian: Ideally we want to optimise all axes relavant to allocation. For
@@ -4249,7 +4271,7 @@ let type_omitted_parameters expected_mode env loc ty_ret mode_ret args =
                Alloc.newvar_above (Alloc.join
                 (mode_partial_fun:: mode_closed_args))
              in
-             register_allocation_mode mode_closure;
+             register_allocation_mode ~loc ~env mode_closure;
              let arg =
               Omitted {
                 mode_closure = Alloc.disallow_left mode_closure;
@@ -5242,7 +5264,7 @@ let split_function_ty
          function deserves a separate allocation mode.
       *)
       let mode, _ = Value.newvar_below (as_single_mode expected_mode) in
-      fst (register_allocation_value_mode mode)
+      fst (register_allocation_value_mode ~loc ~env mode)
   in
   if expected_mode.strictly_local then
     Locality.submode_exn Locality.local
@@ -5636,16 +5658,20 @@ and type_expect_
       end;
       let alloc_mode, record_mode =
         if is_boxed then
-          let alloc_mode, record_mode = register_allocation expected_mode in
+          let alloc_mode, record_mode =
+            register_allocation ~loc ~env expected_mode
+          in
           Some alloc_mode, record_mode
         else
-          None, expected_mode
+          (register_bytecode_allocation ~loc ~env expected_mode;
+          None, expected_mode)
       in
       let type_label_exp overwrite ((_, label, _) as x) =
         check_construct_mutability ~loc ~env label.lbl_mut ~ty:label.lbl_arg
           ~modalities:label.lbl_modalities record_mode;
         let argument_mode = mode_modality label.lbl_modalities record_mode in
-        type_label_exp ~overwrite true env argument_mode loc ty_record x record_form
+        type_label_exp ~overwrite ~create:true env argument_mode loc ty_record x
+          record_form
       in
       let overwrites =
         assign_label_children (List.length lbl_a_list)
@@ -6185,7 +6211,9 @@ and type_expect_
             row_field_repr (get_row_field l row0)
           with
             Rpresent (Some ty), Rpresent (Some ty0) ->
-              let alloc_mode, argument_mode = register_allocation expected_mode in
+              let alloc_mode, argument_mode =
+                register_allocation ~loc ~env expected_mode
+              in
               let arg =
                 type_argument ~overwrite:No_overwrite env argument_mode sarg ty ty0
               in
@@ -6202,9 +6230,12 @@ and type_expect_
         | None -> None
         | Some sarg ->
             let ty_expected =
-              newvar (Jkind.Builtin.value_or_null ~why:Polymorphic_variant_field)
+              newvar
+                (Jkind.Builtin.value_or_null ~why:Polymorphic_variant_field)
             in
-            let alloc_mode, argument_mode = register_allocation expected_mode in
+            let alloc_mode, argument_mode =
+              register_allocation ~loc ~env expected_mode
+            in
             let arg =
               type_expect env argument_mode sarg (mk_expected ty_expected)
             in
@@ -6263,7 +6294,9 @@ and type_expect_
         in
         match is_float_boxing with
         | true ->
-          let alloc_mode, argument_mode = register_allocation expected_mode in
+          let alloc_mode, argument_mode =
+            register_allocation ~loc ~env expected_mode
+          in
           let mode = cross_left env Predef.type_unboxed_float mode in
           submode ~loc ~env mode argument_mode;
           let uu =
@@ -6326,8 +6359,8 @@ and type_expect_
           submode ~loc:record.exp_loc ~env rmode mode_mutate_mutable;
           let mode = mutable_mode m0 |> mode_default in
           let mode = mode_modality label.lbl_modalities mode in
-          type_label_exp ~overwrite:No_overwrite_label false env mode loc ty_record
-            (lid, label, snewval) Legacy
+          type_label_exp ~overwrite:No_overwrite_label ~create:false env mode
+            loc ty_record (lid, label, snewval) Legacy
         | Immutable ->
           raise(Error(loc, env, Label_not_mutable lid.txt))
       in
@@ -7302,6 +7335,7 @@ and type_ident env ?(recarg=Rejected) lid =
   where [m] is the mode of a closure lock. Since join is commutative and
   associative, the order of which we apply those join does not matter.
   *)
+  (* CR jcutler: ensure this argument holds *)
   (* CR modes: codify the above per-axis argument. *)
   let actual_mode =
     Env.walk_locks ~env ~loc:lid.loc lid.txt ~item:Value (Some desc.val_type)
@@ -7336,7 +7370,8 @@ and type_ident env ?(recarg=Rejected) lid =
        (* if the locality of returned value of the primitive is poly
           we then register allocation for further optimization *)
        | (Prim_poly, _), Some mode ->
-           register_allocation_mode (Alloc.max_with_comonadic Areality mode)
+           register_allocation_mode ~loc:lid.loc ~env
+              (Alloc.max_with_comonadic Areality mode)
        | _ -> ()
        end;
        ty, Id_prim (Option.map Locality.disallow_right mode, sort)
@@ -8007,7 +8042,9 @@ and type_format loc str env =
 and type_option_some env expected_mode sarg ty ty0 =
   let ty' = extract_option_type env ty in
   let ty0' = extract_option_type env ty0 in
-  let alloc_mode, argument_mode = register_allocation expected_mode in
+  let alloc_mode, argument_mode =
+    register_allocation ~loc:sarg.pexp_loc ~env expected_mode
+  in
   let arg = type_argument ~overwrite:No_overwrite env argument_mode sarg ty' ty0' in
   let lid = Longident.Lident "Some" in
   let csome = Env.find_ident_constructor Predef.ident_some env in
@@ -8018,10 +8055,11 @@ and type_option_some env expected_mode sarg ty ty0 =
    allocation, mutation and modalities. *)
 and type_label_exp
   : type rep.
-    overwrite:_ -> _ -> _ -> _ -> _ -> _ ->
+    overwrite:_ -> create:_ -> _ -> _ -> _ -> _ ->
     _ * rep gen_label_description * _ -> rep record_form ->
     _ * rep gen_label_description * _
-  = fun ~overwrite create env arg_mode loc ty_expected (lid, label, sarg) record_form ->
+  = fun ~overwrite ~create env arg_mode loc ty_expected
+        (lid, label, sarg) record_form ->
   (* Here also ty_expected may be at generic_level *)
   let separate = !Clflags.principal || Env.has_local_constraints env in
   (* #4682: we try two type-checking approaches for [arg] using backtracking:
@@ -8218,7 +8256,9 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       in
       unify_exp env {texp with exp_type = ty_fun} ty_expected;
       if args = [] then texp else begin
-      let alloc_mode, mode_subcomponent = register_allocation mode in
+      let alloc_mode, mode_subcomponent =
+        register_allocation ~loc:sarg.pexp_loc ~env mode
+      in
       submode ~loc:sarg.pexp_loc ~env ~reason:Other
         exp_mode mode_subcomponent;
       (* eta-expand to avoid side effects *)
@@ -8513,7 +8553,9 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
      we allow non-values in boxed tuples. *)
   let arity = List.length sexpl in
   assert (arity >= 2);
-  let alloc_mode, argument_mode = register_allocation_value_mode expected_mode.mode in
+  let alloc_mode, argument_mode =
+    register_allocation_value_mode ~loc ~env expected_mode.mode
+  in
   let alloc_mode =
     { mode = alloc_mode;
       locality_context = expected_mode.locality_context }
@@ -8541,7 +8583,9 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
         (* If the pattern and the expression have different tuple length, it
           should be an type error. Here, we give the sound mode anyway. *)
         let tuple_modes =
-          List.map (fun mode -> snd (register_allocation_value_mode mode)) tuple_modes
+          List.map
+            (fun mode -> snd (register_allocation_value_mode ~loc ~env mode))
+            tuple_modes
         in
         let argument_mode = Value.meet (argument_mode :: tuple_modes) in
         List.init arity (fun _ -> argument_mode)
@@ -8581,6 +8625,7 @@ and type_unboxed_tuple ~loc ~env ~(expected_mode : expected_mode) ~ty_expected
   Language_extension.assert_enabled ~loc Layouts Language_extension.Stable;
   let arity = List.length sexpl in
   assert (arity >= 2);
+  register_bytecode_allocation ~loc ~env expected_mode;
   let argument_mode = expected_mode.mode in
   (* elements must be representable *)
   let labels_types_and_sorts =
@@ -8732,7 +8777,9 @@ and type_construct ~overwrite env (expected_mode : expected_mode) loc lid sarg
     | Variant_unboxed | Variant_with_null -> expected_mode, None
     | Variant_boxed _ when constr.cstr_constant -> expected_mode, None
     | Variant_boxed _ | Variant_extensible ->
-       let alloc_mode, argument_mode = register_allocation expected_mode in
+       let alloc_mode, argument_mode =
+        register_allocation ~loc ~env expected_mode
+      in
        argument_mode, Some alloc_mode
   in
   begin match overwrite, constr.cstr_repr with
@@ -9708,7 +9755,7 @@ and type_generic_array
       ~attributes
       sargl
   =
-  let alloc_mode, array_mode = register_allocation expected_mode in
+  let alloc_mode, array_mode = register_allocation ~loc ~env expected_mode in
   let type_ =
     if Types.is_mutable mutability then Predef.type_array
     else Predef.type_iarray
@@ -11198,6 +11245,7 @@ let report_error ~loc env =
         | Error (Comonadic Portability, _ ) -> []
         | Error (Comonadic Yielding, _) -> []
         | Error (Comonadic Statefulness, _) -> []
+        | Error (Comonadic Externality, _) -> []
       in
       Location.errorf ~loc ~sub "@[%t@]" begin
         match fail_reason with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -697,6 +697,7 @@ let allocations : Alloc.r list ref = Local_store.s_ref []
 
 let reset_allocations () = allocations := []
 
+<<<<<<< HEAD
 let lower_bound_externality ~loc ~env lower_bound alloc_mode =
   let externality = Alloc.proj_comonadic Externality alloc_mode in
   let res = Externality.submode lower_bound externality in
@@ -715,6 +716,21 @@ let register_bytecode_allocation_mode ~loc ~env alloc_mode =
 
 let register_allocation_mode ~loc ~env alloc_mode =
   lower_bound_externality ~loc ~env Externality.internal alloc_mode;
+=======
+let register_allocation_mode ~loc ~env alloc_mode =
+  let externality = Alloc.proj (Comonadic Externality) alloc_mode in
+  let res = Externality.submode Externality.internal externality in
+  (match res with
+  | Ok () -> ()
+  | Error failure_reason ->
+    (* CR jcutler: do we need to pass values for these contexts? I don't think
+       they have anything to do with the type error we're raising here... *)
+      let error =
+        Submode_failed(Value.Error (Comonadic Externality,failure_reason), Other, None,
+          None, None, None)
+      in
+      raise (Error(loc, env, error)));
+>>>>>>> 6206867253 (add externality modal axis)
   let alloc_mode = Alloc.disallow_left alloc_mode in
   allocations := alloc_mode :: !allocations
 
@@ -5658,9 +5674,13 @@ and type_expect_
       end;
       let alloc_mode, record_mode =
         if is_boxed then
+<<<<<<< HEAD
           let alloc_mode, record_mode =
             register_allocation ~loc ~env expected_mode
           in
+=======
+          let alloc_mode, record_mode = register_allocation ~loc ~env expected_mode in
+>>>>>>> 6206867253 (add externality modal axis)
           Some alloc_mode, record_mode
         else
           (register_bytecode_allocation ~loc ~env expected_mode;
@@ -5670,8 +5690,12 @@ and type_expect_
         check_construct_mutability ~loc ~env label.lbl_mut ~ty:label.lbl_arg
           ~modalities:label.lbl_modalities record_mode;
         let argument_mode = mode_modality label.lbl_modalities record_mode in
+<<<<<<< HEAD
         type_label_exp ~overwrite ~create:true env argument_mode loc ty_record x
           record_form
+=======
+        type_label_exp ~overwrite ~create:true env argument_mode loc ty_record x record_form
+>>>>>>> 6206867253 (add externality modal axis)
       in
       let overwrites =
         assign_label_children (List.length lbl_a_list)
@@ -6211,9 +6235,13 @@ and type_expect_
             row_field_repr (get_row_field l row0)
           with
             Rpresent (Some ty), Rpresent (Some ty0) ->
+<<<<<<< HEAD
               let alloc_mode, argument_mode =
                 register_allocation ~loc ~env expected_mode
               in
+=======
+              let alloc_mode, argument_mode = register_allocation ~loc ~env expected_mode in
+>>>>>>> 6206867253 (add externality modal axis)
               let arg =
                 type_argument ~overwrite:No_overwrite env argument_mode sarg ty ty0
               in
@@ -6236,6 +6264,10 @@ and type_expect_
             let alloc_mode, argument_mode =
               register_allocation ~loc ~env expected_mode
             in
+<<<<<<< HEAD
+=======
+            let alloc_mode, argument_mode = register_allocation ~loc ~env expected_mode in
+>>>>>>> 6206867253 (add externality modal axis)
             let arg =
               type_expect env argument_mode sarg (mk_expected ty_expected)
             in
@@ -6294,9 +6326,13 @@ and type_expect_
         in
         match is_float_boxing with
         | true ->
+<<<<<<< HEAD
           let alloc_mode, argument_mode =
             register_allocation ~loc ~env expected_mode
           in
+=======
+          let alloc_mode, argument_mode = register_allocation ~loc ~env expected_mode in
+>>>>>>> 6206867253 (add externality modal axis)
           let mode = cross_left env Predef.type_unboxed_float mode in
           submode ~loc ~env mode argument_mode;
           let uu =
@@ -6346,6 +6382,7 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_setfield(srecord, lid, snewval) ->
+     (* rmode is the mode of the record. *)
       let (record, _, rmode, label, expected_type) =
         type_label_access Legacy env srecord Env.Mutation lid in
       let ty_record =
@@ -6359,8 +6396,14 @@ and type_expect_
           submode ~loc:record.exp_loc ~env rmode mode_mutate_mutable;
           let mode = mutable_mode m0 |> mode_default in
           let mode = mode_modality label.lbl_modalities mode in
+<<<<<<< HEAD
           type_label_exp ~overwrite:No_overwrite_label ~create:false env mode
             loc ty_record (lid, label, snewval) Legacy
+=======
+          (* This is the mode of the field we're updating. Should be internal. *)
+          type_label_exp ~overwrite:No_overwrite_label ~create:false env mode loc ty_record
+            (lid, label, snewval) Legacy
+>>>>>>> 6206867253 (add externality modal axis)
         | Immutable ->
           raise(Error(loc, env, Label_not_mutable lid.txt))
       in
@@ -7370,8 +7413,12 @@ and type_ident env ?(recarg=Rejected) lid =
        (* if the locality of returned value of the primitive is poly
           we then register allocation for further optimization *)
        | (Prim_poly, _), Some mode ->
+<<<<<<< HEAD
            register_allocation_mode ~loc:lid.loc ~env
               (Alloc.max_with_comonadic Areality mode)
+=======
+           register_allocation_mode ~loc:lid.loc ~env (Alloc.max_with (Comonadic Areality) mode)
+>>>>>>> 6206867253 (add externality modal axis)
        | _ -> ()
        end;
        ty, Id_prim (Option.map Locality.disallow_right mode, sort)
@@ -8042,9 +8089,13 @@ and type_format loc str env =
 and type_option_some env expected_mode sarg ty ty0 =
   let ty' = extract_option_type env ty in
   let ty0' = extract_option_type env ty0 in
+<<<<<<< HEAD
   let alloc_mode, argument_mode =
     register_allocation ~loc:sarg.pexp_loc ~env expected_mode
   in
+=======
+  let alloc_mode, argument_mode = register_allocation ~loc:sarg.pexp_loc ~env expected_mode in
+>>>>>>> 6206867253 (add externality modal axis)
   let arg = type_argument ~overwrite:No_overwrite env argument_mode sarg ty' ty0' in
   let lid = Longident.Lident "Some" in
   let csome = Env.find_ident_constructor Predef.ident_some env in
@@ -8058,14 +8109,19 @@ and type_label_exp
     overwrite:_ -> create:_ -> _ -> _ -> _ -> _ ->
     _ * rep gen_label_description * _ -> rep record_form ->
     _ * rep gen_label_description * _
+<<<<<<< HEAD
   = fun ~overwrite ~create env arg_mode loc ty_expected
         (lid, label, sarg) record_form ->
+=======
+  = fun ~overwrite ~create env arg_mode loc ty_expected (lid, label, sarg) record_form ->
+>>>>>>> 6206867253 (add externality modal axis)
   (* Here also ty_expected may be at generic_level *)
   let separate = !Clflags.principal || Env.has_local_constraints env in
   (* #4682: we try two type-checking approaches for [arg] using backtracking:
      - first try: we try with [ty_arg] as expected type;
      - second try; if that fails, we backtrack and try without
   *)
+    (* CR jcutler: ty_Arg is the expected? real? type of the argument *)
   let (vars, ty_arg, snap, arg) =
     (* try the first approach *)
     with_local_level begin fun () ->
@@ -8256,9 +8312,13 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       in
       unify_exp env {texp with exp_type = ty_fun} ty_expected;
       if args = [] then texp else begin
+<<<<<<< HEAD
       let alloc_mode, mode_subcomponent =
         register_allocation ~loc:sarg.pexp_loc ~env mode
       in
+=======
+      let alloc_mode, mode_subcomponent = register_allocation ~loc:sarg.pexp_loc ~env mode in
+>>>>>>> 6206867253 (add externality modal axis)
       submode ~loc:sarg.pexp_loc ~env ~reason:Other
         exp_mode mode_subcomponent;
       (* eta-expand to avoid side effects *)
@@ -8553,9 +8613,13 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
      we allow non-values in boxed tuples. *)
   let arity = List.length sexpl in
   assert (arity >= 2);
+<<<<<<< HEAD
   let alloc_mode, argument_mode =
     register_allocation_value_mode ~loc ~env expected_mode.mode
   in
+=======
+  let alloc_mode, argument_mode = register_allocation_value_mode ~loc ~env expected_mode.mode in
+>>>>>>> 6206867253 (add externality modal axis)
   let alloc_mode =
     { mode = alloc_mode;
       locality_context = expected_mode.locality_context }
@@ -8583,9 +8647,13 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
         (* If the pattern and the expression have different tuple length, it
           should be an type error. Here, we give the sound mode anyway. *)
         let tuple_modes =
+<<<<<<< HEAD
           List.map
             (fun mode -> snd (register_allocation_value_mode ~loc ~env mode))
             tuple_modes
+=======
+          List.map (fun mode -> snd (register_allocation_value_mode ~loc ~env mode)) tuple_modes
+>>>>>>> 6206867253 (add externality modal axis)
         in
         let argument_mode = Value.meet (argument_mode :: tuple_modes) in
         List.init arity (fun _ -> argument_mode)
@@ -8777,9 +8845,13 @@ and type_construct ~overwrite env (expected_mode : expected_mode) loc lid sarg
     | Variant_unboxed | Variant_with_null -> expected_mode, None
     | Variant_boxed _ when constr.cstr_constant -> expected_mode, None
     | Variant_boxed _ | Variant_extensible ->
+<<<<<<< HEAD
        let alloc_mode, argument_mode =
         register_allocation ~loc ~env expected_mode
       in
+=======
+       let alloc_mode, argument_mode = register_allocation ~loc ~env expected_mode in
+>>>>>>> 6206867253 (add externality modal axis)
        argument_mode, Some alloc_mode
   in
   begin match overwrite, constr.cstr_repr with
@@ -11245,7 +11317,11 @@ let report_error ~loc env =
         | Error (Comonadic Portability, _ ) -> []
         | Error (Comonadic Yielding, _) -> []
         | Error (Comonadic Statefulness, _) -> []
+<<<<<<< HEAD
         | Error (Comonadic Externality, _) -> []
+=======
+        | Error (Comonadic Externality, _) -> [] (* CR jcutler: fixme *)
+>>>>>>> 6206867253 (add externality modal axis)
       in
       Location.errorf ~loc ~sub "@[%t@]" begin
         match fail_reason with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -697,7 +697,6 @@ let allocations : Alloc.r list ref = Local_store.s_ref []
 
 let reset_allocations () = allocations := []
 
-<<<<<<< HEAD
 let lower_bound_externality ~loc ~env lower_bound alloc_mode =
   let externality = Alloc.proj_comonadic Externality alloc_mode in
   let res = Externality.submode lower_bound externality in
@@ -716,21 +715,6 @@ let register_bytecode_allocation_mode ~loc ~env alloc_mode =
 
 let register_allocation_mode ~loc ~env alloc_mode =
   lower_bound_externality ~loc ~env Externality.internal alloc_mode;
-=======
-let register_allocation_mode ~loc ~env alloc_mode =
-  let externality = Alloc.proj (Comonadic Externality) alloc_mode in
-  let res = Externality.submode Externality.internal externality in
-  (match res with
-  | Ok () -> ()
-  | Error failure_reason ->
-    (* CR jcutler: do we need to pass values for these contexts? I don't think
-       they have anything to do with the type error we're raising here... *)
-      let error =
-        Submode_failed(Value.Error (Comonadic Externality,failure_reason), Other, None,
-          None, None, None)
-      in
-      raise (Error(loc, env, error)));
->>>>>>> 6206867253 (add externality modal axis)
   let alloc_mode = Alloc.disallow_left alloc_mode in
   allocations := alloc_mode :: !allocations
 
@@ -5674,13 +5658,9 @@ and type_expect_
       end;
       let alloc_mode, record_mode =
         if is_boxed then
-<<<<<<< HEAD
           let alloc_mode, record_mode =
             register_allocation ~loc ~env expected_mode
           in
-=======
-          let alloc_mode, record_mode = register_allocation ~loc ~env expected_mode in
->>>>>>> 6206867253 (add externality modal axis)
           Some alloc_mode, record_mode
         else
           (register_bytecode_allocation ~loc ~env expected_mode;
@@ -5690,12 +5670,8 @@ and type_expect_
         check_construct_mutability ~loc ~env label.lbl_mut ~ty:label.lbl_arg
           ~modalities:label.lbl_modalities record_mode;
         let argument_mode = mode_modality label.lbl_modalities record_mode in
-<<<<<<< HEAD
         type_label_exp ~overwrite ~create:true env argument_mode loc ty_record x
           record_form
-=======
-        type_label_exp ~overwrite ~create:true env argument_mode loc ty_record x record_form
->>>>>>> 6206867253 (add externality modal axis)
       in
       let overwrites =
         assign_label_children (List.length lbl_a_list)
@@ -6235,13 +6211,9 @@ and type_expect_
             row_field_repr (get_row_field l row0)
           with
             Rpresent (Some ty), Rpresent (Some ty0) ->
-<<<<<<< HEAD
               let alloc_mode, argument_mode =
                 register_allocation ~loc ~env expected_mode
               in
-=======
-              let alloc_mode, argument_mode = register_allocation ~loc ~env expected_mode in
->>>>>>> 6206867253 (add externality modal axis)
               let arg =
                 type_argument ~overwrite:No_overwrite env argument_mode sarg ty ty0
               in
@@ -6264,10 +6236,6 @@ and type_expect_
             let alloc_mode, argument_mode =
               register_allocation ~loc ~env expected_mode
             in
-<<<<<<< HEAD
-=======
-            let alloc_mode, argument_mode = register_allocation ~loc ~env expected_mode in
->>>>>>> 6206867253 (add externality modal axis)
             let arg =
               type_expect env argument_mode sarg (mk_expected ty_expected)
             in
@@ -6326,13 +6294,9 @@ and type_expect_
         in
         match is_float_boxing with
         | true ->
-<<<<<<< HEAD
           let alloc_mode, argument_mode =
             register_allocation ~loc ~env expected_mode
           in
-=======
-          let alloc_mode, argument_mode = register_allocation ~loc ~env expected_mode in
->>>>>>> 6206867253 (add externality modal axis)
           let mode = cross_left env Predef.type_unboxed_float mode in
           submode ~loc ~env mode argument_mode;
           let uu =
@@ -6382,7 +6346,6 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_setfield(srecord, lid, snewval) ->
-     (* rmode is the mode of the record. *)
       let (record, _, rmode, label, expected_type) =
         type_label_access Legacy env srecord Env.Mutation lid in
       let ty_record =
@@ -6397,10 +6360,13 @@ and type_expect_
           let mode = mutable_mode m0 |> mode_default in
           let mode = mode_modality label.lbl_modalities mode in
 <<<<<<< HEAD
+<<<<<<< HEAD
           type_label_exp ~overwrite:No_overwrite_label ~create:false env mode
             loc ty_record (lid, label, snewval) Legacy
 =======
           (* This is the mode of the field we're updating. Should be internal. *)
+=======
+>>>>>>> 2db4608467 (somehow this got missed)
           type_label_exp ~overwrite:No_overwrite_label ~create:false env mode loc ty_record
             (lid, label, snewval) Legacy
 >>>>>>> 6206867253 (add externality modal axis)
@@ -8121,7 +8087,6 @@ and type_label_exp
      - first try: we try with [ty_arg] as expected type;
      - second try; if that fails, we backtrack and try without
   *)
-    (* CR jcutler: ty_Arg is the expected? real? type of the argument *)
   let (vars, ty_arg, snap, arg) =
     (* try the first approach *)
     with_local_level begin fun () ->
@@ -11318,10 +11283,14 @@ let report_error ~loc env =
         | Error (Comonadic Yielding, _) -> []
         | Error (Comonadic Statefulness, _) -> []
 <<<<<<< HEAD
+<<<<<<< HEAD
         | Error (Comonadic Externality, _) -> []
 =======
         | Error (Comonadic Externality, _) -> [] (* CR jcutler: fixme *)
 >>>>>>> 6206867253 (add externality modal axis)
+=======
+        | Error (Comonadic Externality, _) -> []
+>>>>>>> 2db4608467 (somehow this got missed)
       in
       Location.errorf ~loc ~sub "@[%t@]" begin
         match fail_reason with

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -207,6 +207,15 @@ type unsupported_stack_allocation =
   | List_comprehension
   | Array_comprehension
 
+type unsupported_external_allocation =
+  | Lazy
+  | Module
+  | Object
+  | Comprehension
+  | Function
+  | Array
+
+
 type error =
   | Constructor_arity_mismatch of Longident.t * int * int
   | Constructor_labeled_arg
@@ -336,6 +345,7 @@ type error =
   | Cannot_stack_allocate of Env.locality_context option
   | Unsupported_stack_allocation of unsupported_stack_allocation
   | Not_allocation
+  | Unsupported_external_allocation of unsupported_external_allocation
   | Impossible_function_jkind of
       { some_args_ok : bool; ty_fun : type_expr; jkind : jkind_lr }
   | Overwrite_of_invalid_term

--- a/typing/typedecl_separability.ml
+++ b/typing/typedecl_separability.ml
@@ -485,13 +485,9 @@ let msig_of_external_type env decl =
     Result.is_error (Ctype.check_decl_jkind env decl
                         (Jkind.Builtin.value_or_null ~why:Separability_check))
   in
-  let jkind_of_type = Ctype.type_jkind_purely_if_principal env in
-  let is_external =
-    match Jkind.get_externality_upper_bound ~jkind_of_type decl.type_jkind with
-    | Internal -> false
-    | External | External64 -> true
-  in
-  if is_not_value_or_null || is_external then best_msig decl else worst_msig decl
+  (* CR jcutler: There are types that are external but not separable,
+  so externality is no longer sufficient to ensure separability. *)
+  if is_not_value_or_null then best_msig decl else worst_msig decl
 
 (** [msig_of_context ~decl_loc constructor context] returns the
    separability signature of a single-constructor type whose

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -117,6 +117,11 @@ type alloc_mode = {
   locality_context : Env.locality_context option;
 }
 
+type allocator =
+  | Allocator_heap
+  | Allocator_stack
+  | Allocator_malloc
+
 type texp_field_boxing =
   | Boxing of alloc_mode * unique_use
   | Non_boxing of unique_use
@@ -309,6 +314,7 @@ and expression_desc =
   | Texp_src_pos
   | Texp_overwrite of expression * expression
   | Texp_hole of unique_use
+  | Texp_alloc of expression * allocator
 
 and ident_kind =
   | Id_value

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -108,6 +108,11 @@ type alloc_mode = {
   locality_context : Env.locality_context option;
 }
 
+type allocator =
+  | Allocator_heap
+  | Allocator_stack
+  | Allocator_malloc
+
 type texp_field_boxing =
   | Boxing of alloc_mode * unique_use
   (** Projection requires boxing. [unique_use] describes the usage of the
@@ -518,6 +523,8 @@ and expression_desc =
        Position argument in function application *)
   | Texp_overwrite of expression * expression (** overwrite_ exp with exp *)
   | Texp_hole of unique_use (** _ *)
+  (* CR external: at the moment, this is only ever Allocator_malloc. *)
+  | Texp_alloc of expression * allocator
 
 and function_curry =
   | More_args of { partial_mode : Mode.Alloc.l }

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -148,6 +148,8 @@ let register_allocation () =
     Alloc.(newvar_below
       (max_with_comonadic Areality Locality.global))
   in
+  let externality = Alloc.proj_comonadic Externality m in
+  Externality.submode_exn Externality.internal externality;
   m, alloc_as_value m
 
 open Typedtree

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -277,7 +277,7 @@ let transl_mod_bounds annots =
   in
   let externality =
     Option.fold ~some:Location.get_txt ~none:Externality.max
-      modifiers.externality
+      modifiers.externality_mod
   in
   let nullability =
     Option.fold ~some:Location.get_txt ~none:Nullability.max
@@ -489,6 +489,7 @@ let untransl_modality (a : Modality.t) : Parsetree.modality loc =
    removed. The implications on the monadic axes will stay. Implied modalities
    can be overriden. *)
 (* CR zqian: decouple mutable and comonadic modalities *)
+(* CR jcutler: why is this? Why aliased? Can we get away without *)
 let mutable_implied_modalities ~for_mutable_variable (mut : Types.mutability) =
   let comonadic : Modality.t list =
     [ Atom (Comonadic Areality, Meet_with Regionality.Const.legacy);

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -277,7 +277,7 @@ let transl_mod_bounds annots =
   in
   let externality =
     Option.fold ~some:Location.get_txt ~none:Externality.max
-      modifiers.externality_mod
+      modifiers.externality
   in
   let nullability =
     Option.fold ~some:Location.get_txt ~none:Nullability.max
@@ -489,7 +489,6 @@ let untransl_modality (a : Modality.t) : Parsetree.modality loc =
    removed. The implications on the monadic axes will stay. Implied modalities
    can be overriden. *)
 (* CR zqian: decouple mutable and comonadic modalities *)
-(* CR jcutler: why is this? Why aliased? Can we get away without *)
 let mutable_implied_modalities ~for_mutable_variable (mut : Types.mutability) =
   let comonadic : Modality.t list =
     [ Atom (Comonadic Areality, Meet_with Regionality.Const.legacy);

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -89,7 +89,7 @@ let is_base_type env ty base_ty_path =
   | _ -> false
 
 let is_always_gc_ignorable env ty =
-  let ext : Jkind_axis.Externality.t =
+  let externality : Jkind_mod_bounds.Externality.t =
     (* We check that we're compiling to (64-bit) native code before counting
        External64 types as gc_ignorable, because bytecode is intended to be
        platform independent. *)
@@ -97,7 +97,7 @@ let is_always_gc_ignorable env ty =
     then External64
     else External
   in
-  Ctype.check_type_externality env ty ext
+  Ctype.check_type_externality env ty externality
 
 let maybe_pointer_type env ty =
   let ty = scrape_ty env ty in
@@ -400,7 +400,8 @@ let value_kind_of_value_jkind env jkind =
   let jkind_of_type ty = Some (Ctype.type_jkind_purely env ty) in
   let externality_upper_bound = Jkind.get_externality_upper_bound ~jkind_of_type jkind in
   match layout, externality_upper_bound with
-  | Base Value, External -> Pintval
+  | Base Value, External -> if !Clflags.native_code then Pintval else Pgenval
+  | Base Value, Byte_external -> Pintval
   | Base Value, External64 ->
     if !Clflags.native_code && Sys.word_size = 64 then Pintval else Pgenval
   | Base Value, Internal -> Pgenval

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -234,7 +234,6 @@ module Jkind_mod_bounds = struct
       then Externality.min
       else t.externality
     in
-
     let nullability =
       if mem min_axes (Nonmodal Nullability)
       then Nullability.min

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -234,6 +234,7 @@ module Jkind_mod_bounds = struct
       then Externality.min
       else t.externality
     in
+
     let nullability =
       if mem min_axes (Nonmodal Nullability)
       then Nullability.min

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -44,7 +44,7 @@ module Jkind_mod_bounds = struct
   module Yielding = Mode.Yielding.Const
   module Statefulness = Mode.Statefulness.Const
   module Visibility = Mode.Visibility.Const_op
-  module Externality = Jkind_axis.Externality
+  module Externality = Mode.Externality.Const
   module Nullability = Jkind_axis.Nullability
   module Separability = Jkind_axis.Separability
 
@@ -157,7 +157,7 @@ module Jkind_mod_bounds = struct
       else t.visibility
     in
     let externality =
-      if mem max_axes (Nonmodal Externality)
+      if mem max_axes (Modal (Comonadic Externality))
       then Externality.max
       else t.externality
     in
@@ -230,7 +230,7 @@ module Jkind_mod_bounds = struct
       else t.visibility
     in
     let externality =
-      if mem min_axes (Nonmodal Externality)
+      if mem min_axes (Modal (Comonadic Externality))
       then Externality.min
       else t.externality
     in
@@ -276,7 +276,7 @@ module Jkind_mod_bounds = struct
      Statefulness.(le max (statefulness t))) &&
     (not (mem axes (Modal (Monadic Visibility))) ||
      Visibility.(le max (visibility t))) &&
-    (not (mem axes (Nonmodal Externality)) ||
+    (not (mem axes (Modal (Comonadic Externality))) ||
      Externality.(le max (externality t))) &&
     (not (mem axes (Nonmodal Nullability)) ||
      Nullability.(le max (nullability t))) &&

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -81,7 +81,7 @@ module Jkind_mod_bounds : sig
   module Yielding = Mode.Yielding.Const
   module Statefulness = Mode.Statefulness.Const
   module Visibility = Mode.Visibility.Const_op
-  module Externality = Jkind_axis.Externality
+  module Externality = Mode.Externality.Const
   module Nullability = Jkind_axis.Nullability
   module Separability = Jkind_axis.Separability
 

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -779,6 +779,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
                 (newconstr Predef.path_option [Btype.tpoly_get_mono arg_ty])
             end
           in
+
           let arg_mode = Alloc.of_const arg_mode in
           let ret_mode = Alloc.of_const ret_mode in
           let arrow_desc = (l, arg_mode, ret_mode) in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -779,7 +779,6 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
                 (newconstr Predef.path_option [Btype.tpoly_get_mono arg_ty])
             end
           in
-
           let arg_mode = Alloc.of_const arg_mode in
           let ret_mode = Alloc.of_const ret_mode in
           let arrow_desc = (l, arg_mode, ret_mode) in

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -2386,6 +2386,7 @@ let rec check_uniqueness_exp ~overwrite (ienv : Ienv.t) exp : UF.t =
   | Texp_probe { handler } -> check_uniqueness_exp ~overwrite:None ienv handler
   | Texp_probe_is_enabled _ -> UF.unused
   | Texp_exclave e -> check_uniqueness_exp ~overwrite:None ienv e
+  | Texp_alloc (e, _) -> check_uniqueness_exp ~overwrite:None ienv e
   | Texp_src_pos -> UF.unused
   | Texp_overwrite (e1, e2) ->
     let value, uf = check_uniqueness_exp_as_value ienv e1 in

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -726,7 +726,10 @@ let expression sub exp =
     | Texp_overwrite (exp1, exp2) ->
         Pexp_overwrite(sub.expr sub exp1, sub.expr sub exp2)
     | Texp_hole _ -> Pexp_hole
-  in
+    | Texp_alloc (exp,Allocator_malloc) -> Pexp_malloc (sub.expr sub exp)
+    (* CR external: Fix this when other allocators are supported. *)
+    | Texp_alloc (_,_) -> assert false
+          in
   List.fold_right (exp_extra sub) exp.exp_extra
     (Exp.mk ~loc ~attrs desc)
 

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -257,7 +257,7 @@ let classify_expression : Typedtree.expression -> sd =
           (* other cases compile to a lazy block holding a function *)
           Static
       end
-
+    | Texp_alloc _ -> Static
     | Texp_new _
     | Texp_instvar _
     | Texp_object _
@@ -1048,6 +1048,7 @@ let rec expression : Typedtree.expression -> term_judg =
       expression handler << Dereference
     | Texp_probe_is_enabled _ -> empty
     | Texp_exclave e -> expression e
+    | Texp_alloc (e,_) -> expression e
     | Texp_src_pos -> empty
     | Texp_overwrite (exp1, exp2) ->
       (* This is untested, since we currently mark Texp_overwrite as Dynamic and

--- a/typing/vicuna_traverse_typed_tree.ml
+++ b/typing/vicuna_traverse_typed_tree.ml
@@ -87,13 +87,13 @@ let scrape_poly env ty =
 
 (* See [scrape_ty]; this returns the [type_desc] of a scraped [type_expr]. *)
 let is_always_gc_ignorable env ty =
-  let ext : Jkind_axis.Externality.t =
+  let externality : Jkind_mod_bounds.Externality.t =
     (* We check that we're compiling to (64-bit) native code before counting
        External64 types as gc_ignorable, because bytecode is intended to be
        platform independent. *)
     if !Clflags.native_code && Sys.word_size = 64 then External64 else External
   in
-  Ctype.check_type_externality env ty ext
+  Ctype.check_type_externality env ty externality
 
 type classification =
   | Int (* any immediate type *)


### PR DESCRIPTION
Adds syntax and typechecking support for `malloc_`.

- Currently, (boxed) records, (boxed) tuples, and constructors/variants that allocate can be `malloc_`'d.
- Typing-wise, all components of a `malloc_`'d block must be `external_`.  `malloc_` itself returns a `'a mallocd`, a new builtin of kind `bits64`.
- This syntax is preliminary and subject to change.
- In this PR, `malloc_` is semantically a no-op. No off-heap allocation occurs, the block is heap-allocated as usual.