### PR TITLE
Stringlike indexing with `Naked_nativeint` instead of `Naked_immediate`

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -677,10 +677,16 @@ let convert_index_to_tagged_int ~index ~(index_kind : Lambda.array_index_kind) =
              },
            index ))
 
+let convert_index_to_naked_nativeint ~index ~(index_kind : Lambda.array_index_kind)
+    =
+  let src = convert_lambda_index_to_standard_int_or_float index_kind in
+  H.Prim (Unary (Num_conv { src; dst = Naked_nativeint }, index))
+
 let convert_index_to_untagged_int ~index ~(index_kind : Lambda.array_index_kind)
     =
   let src = convert_lambda_index_to_standard_int_or_float index_kind in
   H.Prim (Unary (Num_conv { src; dst = Naked_immediate }, index))
+
 
 let convert_index_to_naked_int64 ~index ~(index_kind : Lambda.array_index_kind)
     =
@@ -893,7 +899,7 @@ let string_like_load ~dbg ~unsafe
     (kind : P.string_like_value) mode ~boxed string ~index_kind index
     ~current_region =
   let unsafe_load =
-    let index = convert_index_to_untagged_int ~index ~index_kind in
+    let index = convert_index_to_naked_nativeint ~index ~index_kind in
     let wrap =
       match access_size, mode with
       | (Eight | Sixteen), None ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -682,12 +682,6 @@ let convert_index_to_naked_nativeint ~index ~(index_kind : Lambda.array_index_ki
   let src = convert_lambda_index_to_standard_int_or_float index_kind in
   H.Prim (Unary (Num_conv { src; dst = Naked_nativeint }, index))
 
-let convert_index_to_untagged_int ~index ~(index_kind : Lambda.array_index_kind)
-    =
-  let src = convert_lambda_index_to_standard_int_or_float index_kind in
-  H.Prim (Unary (Num_conv { src; dst = Naked_immediate }, index))
-
-
 let convert_index_to_naked_int64 ~index ~(index_kind : Lambda.array_index_kind)
     =
   let src = convert_lambda_index_to_standard_int_or_float index_kind in
@@ -946,7 +940,7 @@ let bytes_like_set ~dbg ~unsafe
     ~(access_size : Flambda_primitive.string_accessor_width) ~machine_width
     (kind : P.bytes_like_value) ~boxed bytes ~index_kind index new_value =
   let unsafe_set =
-    let index = convert_index_to_untagged_int ~index ~index_kind in
+    let index = convert_index_to_naked_nativeint ~index ~index_kind in
     let wrap =
       match access_size with
       | Eight | Sixteen ->

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -777,7 +777,7 @@ let array_index_kind = K.value
 
 let string_or_bigstring_index_kind = K.naked_nativeint
 
-let bytes_or_bigstring_index_kind = K.naked_immediate
+let bytes_or_bigstring_index_kind = K.naked_nativeint
 
 type 'signed_or_unsigned comparison =
   | Eq

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -775,7 +775,7 @@ let string_or_bytes_kind = K.value
 
 let array_index_kind = K.value
 
-let string_or_bigstring_index_kind = K.naked_immediate
+let string_or_bigstring_index_kind = K.naked_nativeint
 
 let bytes_or_bigstring_index_kind = K.naked_immediate
 

--- a/middle_end/flambda2/tests/mlexamples/tests14.flt
+++ b/middle_end/flambda2/tests/mlexamples/tests14.flt
@@ -12,7 +12,7 @@ let code size(7)
         my_closure my_region my_ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let prim = %num_conv (imm tagged -> imm) n in
+  let prim = %num_conv (imm tagged -> nativeint) n in
   let prim_1 = %string_load 8 (s, prim) in
   let Pstringrefu = %Tag_imm prim_1 in
   cont k (Pstringrefu)
@@ -97,7 +97,7 @@ let code loopify(never) size(7) newer_version_of(nth_char_1)
         my_closure my_region my_ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let prim = %num_conv (imm tagged -> imm) n in
+  let prim = %num_conv (imm tagged -> nativeint) n in
   let prim_1 = %string_load 8 (s, prim) in
   let Pstringrefu = %Tag_imm prim_1 in
   cont k (Pstringrefu)

--- a/middle_end/flambda2/tests/mlexamples/tests15.flt
+++ b/middle_end/flambda2/tests/mlexamples/tests15.flt
@@ -47,7 +47,7 @@ let code size(6)
         -> k * k1
         : imm tagged =
   let prim = %untag_imm 120 in
-  let prim_1 = %num_conv (imm tagged -> imm) i in
+  let prim_1 = %num_conv (imm tagged -> nativeint) i in
   let Pbytessetu = %bytes_set 8 b.(prim_1) prim in
   cont k (Pbytessetu)
 in
@@ -173,7 +173,7 @@ let code loopify(never) size(5) newer_version_of(set_to_x_2)
         my_closure my_region my_ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let prim = %num_conv (imm tagged -> imm) i in
+  let prim = %num_conv (imm tagged -> nativeint) i in
   let Pbytessetu = %bytes_set 8 b.(prim) 120i in
   cont k (0)
 in


### PR DESCRIPTION
This PR changes the flambda kind of the index position of bigstring/bytes/string load/store primitives from `Naked_immediate` to `Naked_nativeint`.

This fixes an issue where indexing into a bigstring with a `Naked_Nativeint` generated incorrect code that computes the index as `((i << 1) >> 1)`, roundtripping through `Naked_immediate`.

```
external get64 : t -> int32# -> int64# = "%caml_bigstring_get32u#_indexed_by_int64#"
let f buf i = get64 buf i

(* CMM, before:
(function{tmp/test.ml:6,6-27} camlTest__f_0_1_code
     (buf/379: val i/380: int) : int
 (let ba_data/382 (load_mut int (+a buf/379 8))
   (load_mut int (+ ba_data/382 (>>s (<< i/380 1) 1)))) )

CMM, after:
(function{tmp/test.ml:6,6-27} camlTest__f_0_1_code
     (buf/379: val i/380: int) : int
 (let ba_data/382 (load_mut int (+a buf/379 8))
   (load_mut int (+ ba_data/382 i/380))) )
*)
```

I'm not sure how best to test this PR. I've changed the codegen tests in `middle_end/` to reflect the new cast, and the random testing in `/typing-layouts/unboxed_int_stringlike_indexing.ml` continues to pass.